### PR TITLE
Position header/body without translations at < 600px

### DIFF
--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -55,6 +55,22 @@ span.search-highlight {
     left: 300px;
   }
 }
+@media (max-width: 600px) {
+  .book.with-summary .book-header.fixed {
+    left: calc(100% - 60px);
+    min-width: 300px;
+  }
+  .book.with-summary .book-body {
+    -webkit-transform: none;
+    -moz-transform: none;
+    -ms-transform: none;
+    -o-transform: none;
+    transform: none;
+    left: calc(100% - 60px);
+    min-width: 300px;
+  }
+}
+
 .book .book-body.fixed .body-inner {
   top: 50px;
 }


### PR DESCRIPTION
This change fixes a problem wherein the header scrolled with the body when the page is < 600px. 

The problem is somewhat subtle: at < 600px, CSS translations are used to shift the body contents to the left to accommodate the sidebar (this happens near the end of the minified `style.css`). Unfortunately, a side effect of using CSS transforms such as translations is that they unstick fixed content (i.e. they operate on all nested elements, even if those elements were formerly positioned relative to something else.) 

The fix here is to override the translations applied by the stylesheet, and to use ordinary CSS positioning properties at < 600px to lay out the columns. 