### PR TITLE
tweaks to example book

### DIFF
--- a/inst/examples/_output.yml
+++ b/inst/examples/_output.yml
@@ -1,6 +1,6 @@
 bookdown::gitbook:
   css: css/style.css
-  split_by: section
+  split_by: chapter
   config:
     toc:
       collapse: subsection

--- a/inst/examples/index.Rmd
+++ b/inst/examples/index.Rmd
@@ -4,7 +4,7 @@ author: "Yihui Xie"
 date: "`r Sys.Date()`"
 knit: "bookdown::render_book"
 documentclass: book
-bibliography: [book.bib, packages.bib]
+bibliography: [book.bib]
 biblio-style: apalike
 link-citations: yes
 ---


### PR DESCRIPTION
- split_by: chapter (that's the default and it works better with chapter preview)
- remove packages.bib from bibliography (it's .gitignored so results in an error)