### PR TITLE
Improvements to publish_book

### DIFF
--- a/man/publish_book.Rd
+++ b/man/publish_book.Rd
@@ -3,7 +3,8 @@
 \alias{publish_book}
 \title{Publish a book to the web}
 \usage{
-publish_book(name = NULL, account = NULL, server = "beta.rstudioconnect.com")
+publish_book(name = NULL, account = NULL, server = NULL, 
+    render = getOption("bookdown.render_on_publish", FALSE))
 }
 \arguments{
 \item{name}{Name of the book (this will be used in the URL path of the published book).
@@ -14,6 +15,11 @@ to account or any single account already associated with \code{server}.}
 
 \item{server}{Server to publish to (by default beta.rstudioconnect.com
 but any RStudio Connect server can be published to).}
+
+\item{render}{\code{TRUE} to render all formats prior to publishing (defaults to
+\code{FALSE}, however this can be modified via the \code{bookdown.render_on_publish}
+option). Note that this requires the use of a Makefile to provide the
+implementaiton of rendering all formats.}
 }
 \description{
 Publish a book to the web. Note that you should be sure to render all versions


### PR DESCRIPTION
- Support for automatic updating of existing deployments with no arguments to publish_book (i.e. inherit the name, account, and server of the previous deployment so long as there is only one)

- Provide option to render book before publishing. This defaults to FALSE but can default to TRUE via the setting of a global bookdown option (this is for users that want to always render before publishing and don't want to have to remember to pass render = TRUE)