### PR TITLE
remove rstudio preview tweaks

### DIFF
--- a/inst/resources/gitbook/js/plugin-bookdown.js
+++ b/inst/resources/gitbook/js/plugin-bookdown.js
@@ -192,12 +192,11 @@ require(["gitbook", "lodash", "jQuery"], function(gitbook, _, $) {
     if (!inIframe) return false;
     return /^\/rmd_output\/[0-9]+\/$/.test(window.location.pathname);
   };
-  if (inRStudio()) $(window).on('blur', saveScrollPos);
+  if (inRStudio()) $(window).on('unload', saveScrollPos);
 
   $(document).ready(function(e) {
     var pos = gs.get('bodyScrollTop');
     if (pos && pos.title === bookInner.find('.page-inner').find('h1,h2').first().text()) {
-      window.location.hash = '';
       if (pos.body !== 0) bookBody.scrollTop(pos.body);
       if (pos.inner !== 0) bookInner.scrollTop(pos.inner);
     }


### PR DESCRIPTION
- I've now put in a fix that makes 'unload' work properly in the external preview window. I also noticed that 'blur' doesn't work for some situations (i.e. manually refreshing in the preview window)

- The window.location.hash doesn't seem to have the desired effect. I think it's on RStudio to NOT do the hash restoration in the first place here.