### PR TITLE
Use rsconnect::deploySite for publish_book

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,9 +18,9 @@ Imports:
     htmltools (>= 0.3.5),
     knitr,
     miniUI,
-    rmarkdown (>= 0.9.5),
+    rmarkdown (>= 0.9.5.3),
     yaml,
-    rsconnect (>= 0.4.2)
+    rsconnect (>= 0.4.2.1)
 Suggests:
     htmlwidgets,
     rstudioapi,
@@ -33,3 +33,5 @@ URL: https://github.com/rstudio/bookdown
 BugReports: https://github.com/rstudio/bookdown/issues
 LazyData: TRUE
 RoxygenNote: 5.0.1
+Remotes: rstudio/rmarkdown, rstudio/rsconnect
+

--- a/man/publish_book.Rd
+++ b/man/publish_book.Rd
@@ -3,7 +3,7 @@
 \alias{publish_book}
 \title{Publish a book to the web}
 \usage{
-publish_book(name = NULL, account = NULL, server = NULL, 
+publish_book(name = NULL, account = NULL, server = NULL, sourceCode = FALSE, 
     render = getOption("bookdown.render_on_publish", FALSE))
 }
 \arguments{
@@ -17,6 +17,9 @@ published to account or any single account already associated with
 
 \item{server}{Server to publish to (by default beta.rstudioconnect.com but
 any RStudio Connect server can be published to).}
+
+\item{sourceCode}{Should the book's source code be included in the
+upload?}
 
 \item{render}{\code{TRUE} to render all formats prior to publishing (defaults
 to \code{FALSE}, however, this can be modified via the


### PR DESCRIPTION
We have now made all of the functionality formerly provided by `publish_book` generic for all types of websites (via the `rmarkdown::site_generator` mechanism). As a result, `publish_book` can now just delegate to `rsconnect::deploySite`. 

Users could now simply call `rsconnect::deploySite` rather than `publish_book`, however the latter includes automatic provisioning of an account on bookdown.org which is a nice simplification of workflow. If the think that this doesn't justify having our own function though we could simply dispense with `publish_book` entirely.
