### PR TITLE
accept input_file argument to site_generator$render

### DIFF
--- a/R/site.R
+++ b/R/site.R
@@ -27,8 +27,13 @@ site = function(input, ...) {
   # Custom render function. bookdown rendering is more complex than
   # for most formats and as a result uses a custom R script (_render.R)
   # or Makefile to define what's required to render the book.
-  render = function(output_format, envir, quiet, encoding, ...) {
-    in_dir(input, render_book_script(output_format, envir, quiet))
+  render = function(input_file, output_format, envir, quiet, encoding, ...) {
+    # input_file indicates that caller (likely the IDE) would like to
+    # build a single file of the website only
+    if (!is.null(input_file))
+      render_book(input_file, envir = envir, preview = TRUE)
+    else
+      in_dir(input, render_book_script(output_format, envir, quiet))
   }
 
   # return site generator


### PR DESCRIPTION
If a single file is passed to rmarkdown::render_site then this file is forwarded to the generator's render function as 'input_file'. This currently occurs when the IDE processes a "Knit" for a file within a website so we turn this into a single chapter preview.

Note that with this change knit: bookdown::preview_chapter will no longer be necessary to get single-file incremental preview in the IDE (this change should be in tomorrow's daily build of the IDE).