### PR TITLE
implement rmarkdown site generator clean function

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -207,5 +207,6 @@ clean_book = function(clean = getOption('bookdown.clean_book', FALSE)) {
       'These files/dirs can probably be removed: \n\n', paste(out, collapse = '\n'),
       '\n\nYou can set options(bookdown.clean_book = TRUE) to allow this function to always clean up the book directory for you.'
     )
+    out
   }
 }

--- a/R/site.R
+++ b/R/site.R
@@ -36,11 +36,16 @@ bookdown_site = function(input, ...) {
       in_dir(input, render_book_script(output_format, envir, quiet))
   }
 
+  clean = function() {
+    suppressMessages(clean_book(clean = FALSE))
+  }
+
   # return site generator
   list(
     name = name,
     output_dir = book_dir,
-    render = render
+    render = render,
+    clean = clean
   )
 }
 


### PR DESCRIPTION
There is a new `clean` function which site generators must implement. It returns a site-relative list of files that should be cleaned (the `clean_site` wrapper function is the one that actually does the removal when the `preview` argument to `clean_site` is FALSE.

I was able to re-use the existing `clean_book` function by just arranging for it to return the `out` vector for `clean = FALSE`.