### PR TITLE
phantomjs mirror

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - export BUILD_ALL="$(git log --format=%B --no-merges -n 1 | grep -E "\[build all\]")"
 
 before_script:
-  - "[ -x \"$HOME/bin/phantomjs\" ] || Rscript -e \"webshot::install_phantomjs()\""
+  - "[ -x \"$HOME/bin/phantomjs\" ] || Rscript -e \"webshot::install_phantomjs(baseURL="https://github.com/paladox/phantomjs/releases/download/2.1.7/")\""
   - R CMD INSTALL .
   - cd inst/examples
   - "[ ! -z \"$BUILD_ALL\" ] && make all || make gitbook"


### PR DESCRIPTION
CI's are failing randomly because the phantomjs downloads can fail. For example, see https://travis-ci.org/rstudio/bookdown/builds/128022555

For background of the problem: https://github.com/ariya/phantomjs/issues/13953

webshot updated here: https://github.com/wch/webshot/pull/21