### PR TITLE
add post_processor to word_document2

### DIFF
--- a/R/word.R
+++ b/R/word.R
@@ -14,6 +14,12 @@ word_document2 = function(fig_caption = TRUE, md_extensions = NULL, pandoc_args 
     process_markdown(input_file, from, pandoc_args, TRUE)
     if (is.function(pre)) pre(metadata, input_file, ...)
   }
+  config$post_processor = function(metadata, input, output, clean, verbose) {
+    if (is.null(opts$get('output_dir'))) return(output)
+    output2 = output_path(output)
+    file.rename(output, output2)
+    output2
+  }
   config$bookdown_output_format = 'docx'
   config = set_opts_knit(config)
   config


### PR DESCRIPTION
When using `word_document2` to publish a *docx* document as any other format (epud, pdf, mobi), the docx document is not moved automaticallly in *output_dir*, even if it is specified in *_bookdown.yml*. 

For function, `epub_book` it works because it has a post_processor function that move the epub document in `output_dir`, as specified in *_bookdown.yml*.

I propose to add the same function to the `word_document2` function so that when we use `bookdown::word_document2` in *_output.yml* or in yaml header in *index.Rmd*, the *docx* file is moved in output dir with others. 

Moreover, that way, adding

```r
download: ["epub", "docx"]
```
in *_output.yml* for `bookdown::gitbook:` config will work without any manual operation. 

What do you think? 

However, I do not know if I had to put 

```r
post = config$post_processor
```
and call it in the function, as you did with 
```r
pre = config$pre_processor
```
and 

```r
if (is.function(pre)) pre(metadata, input_file, ...)
```

`rmarkdown::word_document` have `NULL` as `post_processor` element.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rstudio/bookdown/161)
<!-- Reviewable:end -->
