### PR TITLE
Added simpler method for publishing book to gh-pages via /docs folder

### DIFF
--- a/inst/examples/05-publishing.Rmd
+++ b/inst/examples/05-publishing.Rmd
@@ -21,9 +21,11 @@ If you have set up your own RStudio Connect server, you can certainly publish th
 
 ## GitHub
 
-You can host your book on GitHub for free via GitHub Pages (https://pages.github.com). GitHub supports Jekyll (http://jekyllrb.com), a static website builder, to build a website from Markdown files. That may be the more common use case of GitHub Pages, but GitHub also supports arbitrary static HTML files, so you can just host the HTML output files of your book on GitHub. To publish to your book to GitHub Pages, you need to create a `gh-pages` branch in your repository, build the book, put the HTML output (including all external resources like images, CSS, and JavaScript files) in this branch, and push the branch to the remote repository.
+You can host your book on GitHub for free via GitHub Pages (https://pages.github.com). GitHub supports Jekyll (http://jekyllrb.com), a static website builder, to build a website from Markdown files. That may be the more common use case of GitHub Pages, but GitHub also supports arbitrary static HTML files, so you can just host the HTML output files of your book on GitHub. 
 
-If your book repository does not have the `gh-pages` branch, you may use the following commands to create one:
+One approach to publish your book as a GitHub Pages site from a `/docs` folder on your `master` branch as described in [GitHub Help](https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/). First set the output directory of your book to be `/docs` by adding the line `output_dir: "docs"` to the configuration file `_bookdown.yml`. Then after pushing your changes to GitHub go to your repository's settings and under "GitHub Pages" change the "Source" to be "master branch /docs folder".
+
+An alternative approach is to create a `gh-pages` branch in your repository, build the book, put the HTML output (including all external resources like images, CSS, and JavaScript files) in this branch, and push the branch to the remote repository. If your book repository does not have the `gh-pages` branch, you may use the following commands to create one:
 
 ```bash
 # assume you have initialized the git repository,


### PR DESCRIPTION
Using the `/docs` folder approach to publishing to gh-pages requires less steps than via a gh-pages branch.