### PR TITLE
Add author affiliation

### DIFF
--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -27,6 +27,10 @@ $for(author-meta)$
 <meta name="author" content="$author-meta$">
 $endfor$
 
+$if(institute-meta)$
+<meta name="institute" content="$institute-meta$">
+$endif$
+  
 $if(date-meta)$
 <meta name="date" content="$date-meta$">
 $endif$


### PR DESCRIPTION
Add author affiliation in the YAML metadata block using the `institute` field. This field is available in other templates, such as in the default beamer template. See, for example, http://stackoverflow.com/a/35888123/3365410.