### PR TITLE
link to Text references page from Figure captions

### DIFF
--- a/inst/examples/02-components.Rmd
+++ b/inst/examples/02-components.Rmd
@@ -464,6 +464,8 @@ The disadvantage of typesetting figures in this way is that when there is not en
 
 If we assign a figure caption to a code chunk via the chunk option `fig.cap`, R plots will be put into figure environments, which will be automatically labeled and numbered, and can also be cross-referenced. The label of a figure environment is generated from the label of the code chunk, e.g., if the chunk label is `foo`, the figure label will be `fig:foo` (the prefix `fig:` is added before `foo`). To reference a figure\index{cross-reference}, use the syntax `\@ref(label)`,^[Do not forget the leading backslash! And also note the parentheses `()` after `ref`; they are not curly braces `{}`.] where `label` is the figure label, e.g., `fig:foo`.
 
+Note that if you would like to take advantage of markdown formatting _within_ the figure caption, you will need to use [Text references].
+
 ```{block2, type='rmdimportant'}
 If you want to cross-reference figures or tables generated from a code chunk, please make sure the chunk label only contains _alphanumeric_ characters (a-z, A-Z, 0-9), slashes (/), or dashes (-).
 ```


### PR DESCRIPTION
In trying to solve an [issue with using markdown in figure captions](https://github.com/yihui/knitr/issues/1334), I looked through the "Figure" section of the docs without realizing the relevant answer was hiding in the "Text references" section. This cross-reference will hopefully help other users find the answer more quickly.