### PR TITLE
move include-before to allow includes: before_body to put HTML on page

### DIFF
--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -75,10 +75,6 @@ $endfor$
 
 <body>
 
-$for(include-before)$
-$include-before$
-$endfor$
-
 <!--bookdown:title:start-->
 $if(title)$
 <div id="$idprefix$header">
@@ -134,6 +130,11 @@ $endif$
             <section class="normal" id="section-">
 <!--bookdown:toc:end-->
 <!--bookdown:body:start-->
+              
+$for(include-before)$
+$include-before$
+$endfor$
+              
 $body$
 <!--bookdown:body:end-->
 $for(include-after)$

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -75,6 +75,10 @@ $endfor$
 
 <body>
 
+$for(include-before)$
+$include-before$
+$endfor$
+
 <!--bookdown:title:start-->
 $if(title)$
 <div id="$idprefix$header">
@@ -129,16 +133,8 @@ $endif$
 
             <section class="normal" id="section-">
 <!--bookdown:toc:end-->
-              
-$for(include-before)$
-$include-before$
-$endfor$
-              
-<!--bookdown:body:start-->          
+<!--bookdown:body:start-->
 $body$
-              
-
-              
 <!--bookdown:body:end-->
 $for(include-after)$
 $include-after$

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -130,14 +130,14 @@ $endif$
             <section class="normal" id="section-">
 <!--bookdown:toc:end-->
 <!--bookdown:body:start-->
-              
 
-              
-$body$
-              
 $for(include-before)$
 $include-before$
 $endfor$
+          
+$body$
+              
+
               
 <!--bookdown:body:end-->
 $for(include-after)$

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -129,12 +129,12 @@ $endif$
 
             <section class="normal" id="section-">
 <!--bookdown:toc:end-->
-<!--bookdown:body:start-->
-
+              
 $for(include-before)$
 $include-before$
 $endfor$
-          
+              
+<!--bookdown:body:start-->          
 $body$
               
 

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -75,9 +75,7 @@ $endfor$
 
 <body>
 
-$for(include-before)$
-$include-before$
-$endfor$
+
 
 <!--bookdown:title:start-->
 $if(title)$
@@ -132,6 +130,9 @@ $endif$
           <div class="page-inner">
 
             <section class="normal" id="section-">
+$for(include-before)$
+$include-before$
+$endfor$
 <!--bookdown:toc:end-->
 <!--bookdown:body:start-->
 $body$

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -131,11 +131,14 @@ $endif$
 <!--bookdown:toc:end-->
 <!--bookdown:body:start-->
               
+
+              
+$body$
+              
 $for(include-before)$
 $include-before$
 $endfor$
               
-$body$
 <!--bookdown:body:end-->
 $for(include-after)$
 $include-after$


### PR DESCRIPTION
Following the suggestion in https://github.com/rstudio/bookdown/issues/265, this means we can use `_output.yml` to inject text and HTML just above each chapter/section title like this:

```
bookdown::gitbook:
  includes:
    before_body: xxxx.html
```