### PR TITLE
Modifed caption search in parse_fig_labels()

### DIFF
--- a/R/html.R
+++ b/R/html.R
@@ -518,7 +518,7 @@ parse_fig_labels = function(content, global = FALSE) {
       k = max(figs[figs <= i])
       content[k] = paste0(content[k], sprintf('<span id="%s"></span>', lab))
     }, tab = {
-      if (length(grep('^<caption>', content[i - 0:1])) == 0) next
+      if (length(grep('^<caption', content[i - 0:1])) == 0) next
       labs[[i]] = sprintf(
         '<span id="%s">%s</span>', lab, paste0(label_prefix(type), num, ': ')
       )


### PR DESCRIPTION
Originally looking for `<caption>` fails to find `caption` tags that
include attributes. Allowing for attributes paves the way for using
`\@ref` syntax with custom HTML tables.

This is addresses #372