### PR TITLE
clean up deploy branch before deploying

### DIFF
--- a/inst/examples/06-publishing.Rmd
+++ b/inst/examples/06-publishing.Rmd
@@ -68,6 +68,7 @@ git clone -b gh-pages \
   https://${GITHUB_PAT}@github.com/${TRAVIS_REPO_SLUG}.git \
   book-output
 cd book-output
+git rm -rf *
 cp -r ../_book/* ./
 git add --all *
 git commit -m"Update the book"


### PR DESCRIPTION
This makes sure the deploy `gh-pages` branch is empty, before copying in the current compiled bookdown project.
Because hidden files are unaffected by `*` the `.nojekyll` remains.

*Without* this clean-up, the current version of the script can lead to quite unintuitive behavior: even if you delete some file (say, chapter `foo.Rmd`) from the source, and have it compiled *without* it, the respective `foo.html` *will* remain on `gh-pages` forever.
It will be somewhat orphaned, because it would no longer be linked from `index.html`, but it would still be out there.
Potentially quite confusing.