### PR TITLE
Add Exercise and Solution to included theorem/proof environments

### DIFF
--- a/R/html.R
+++ b/R/html.R
@@ -465,14 +465,14 @@ label_names = list(fig = 'Figure ', tab = 'Table ', eq = 'Equation ')
 # prefixes for theorem environments
 theorem_abbr = c(
   theorem = 'thm', lemma = 'lem', definition = 'def', corollary = 'cor',
-  proposition = 'prp', example = 'ex'
+  proposition = 'prp', example = 'ex', exercise = 'exer'
 )
 # numbered math environments
 label_names_math = setNames(list(
-  'Theorem ', 'Lemma ', 'Definition ', 'Corollary ', 'Proposition ', 'Example '
+  'Theorem ', 'Lemma ', 'Definition ', 'Corollary ', 'Proposition ', 'Example ', 'Exercise '
 ), theorem_abbr)
 # unnumbered math environments
-label_names_math2 = list(proof = 'Proof. ', remark = 'Remark. ')
+label_names_math2 = list(proof = 'Proof. ', remark = 'Remark. ', solution = 'Solution. ')
 all_math_env = c(names(theorem_abbr), names(label_names_math2))
 
 label_names = c(label_names, label_names_math)

--- a/R/html.R
+++ b/R/html.R
@@ -465,7 +465,7 @@ label_names = list(fig = 'Figure ', tab = 'Table ', eq = 'Equation ')
 # prefixes for theorem environments
 theorem_abbr = c(
   theorem = 'thm', lemma = 'lem', definition = 'def', corollary = 'cor',
-  proposition = 'prp', example = 'ex', exercise = 'exer'
+  proposition = 'prp', example = 'ex', exercise = 'exr'
 )
 # numbered math environments
 label_names_math = setNames(list(

--- a/R/latex.R
+++ b/R/latex.R
@@ -231,7 +231,7 @@ restore_block2 = function(x, global = FALSE) {
   x
 }
 
-style_definition = c('definition', 'example')
+style_definition = c('definition', 'example', 'exercise')
 style_remark = c('remark')
 # which styles of theorem environments to use
 theorem_style = function(env) {


### PR DESCRIPTION
Exercise falls under the Definition category. Solution falls under the Proof category. I suspect these will be of widespread interest to authors writing activities and solutions. I was not sure how to test these changes. Considered adding an additional activity/solution example to 02-components.Rmd, but did not do so.