### PR TITLE
add .nojekyll when doing /docs approach

### DIFF
--- a/inst/examples/06-publishing.Rmd
+++ b/inst/examples/06-publishing.Rmd
@@ -21,9 +21,21 @@ If you have set up your own RStudio Connect server, you can certainly publish th
 
 ## GitHub
 
-You can host your book on GitHub\index{GitHub} for free via GitHub Pages (https://pages.github.com). GitHub supports Jekyll (http://jekyllrb.com), a static website builder, to build a website from Markdown files. That may be the more common use case of GitHub Pages, but GitHub also supports arbitrary static HTML files, so you can just host the HTML output files of your book on GitHub. 
+You can host your book on GitHub\index{GitHub} for free via GitHub Pages (https://pages.github.com). GitHub supports Jekyll (http://jekyllrb.com), a static website builder, to build a website from Markdown files. That may be the more common use case of GitHub Pages, but GitHub also supports arbitrary static HTML files, so you can just host the HTML output files of your book on GitHub. The key is to create a hidden file `.nojekyll` that tells GitHub that your website is not to be built via Jekyll, since the **bookdown** HTML output is already a standalone website. 
 
-One approach is to publish your book as a GitHub Pages site from a `/docs` folder on your `master` branch as described in [GitHub Help.](http://bit.ly/2cvloKV) First, set the output directory of your book to be `/docs` by adding the line `output_dir: "docs"` to the configuration file `_bookdown.yml`. Then, after pushing your changes to GitHub, go to your repository's settings and under "GitHub Pages" change the "Source" to be "master branch /docs folder".
+```bash
+# assume you have initialized the git repository,
+# and are under the directory of the book repository now
+
+# create a hidden file .nojekyll
+touch .nojekyll
+# add to git here because won't show up in RStudio
+git add .nojekyll
+```
+
+If you are on Windows, you may not have the `touch` command, and you can create the file in R using `file.create('.nojekyll')`.
+
+One approach is to publish your book as a GitHub Pages site from a `/docs` folder on your `master` branch as described in [GitHub Help.](http://bit.ly/2cvloKV) First, set the output directory of your book to be `/docs` by adding the line `output_dir: "docs"` to the configuration file `_bookdown.yml`. Then, after pushing your changes to GitHub, go to your repository's settings and under "GitHub Pages" change the "Source" to be "master branch /docs folder". In this case the `.nojekyll` file has to be in the `/docs` folder. 
 
 An alternative approach is to create a `gh-pages` branch in your repository, build the book, put the HTML output (including all external resources like images, CSS, and JavaScript files) in this branch, and push the branch to the remote repository. If your book repository does not have the `gh-pages` branch, you may use the following commands to create one:
 
@@ -42,8 +54,6 @@ git add .nojekyll
 git commit -m"Initial commit"
 git push origin gh-pages
 ```
-
-The hidden file `.nojekyll` tells GitHub that your website is not to be built via Jekyll, since the **bookdown** HTML output is already a standalone website. If you are on Windows, you may not have the `touch` command, and you can create the file in R using `file.create('.nojekyll')`.
 
 After you have set up GIT, the rest of work can be automated via a script (Shell, R, or Makefile, depending on your preference). Basically, you compile the book to HTML, then run git commands to push the files to GitHub, but you probably do not want to do this over and over again manually and locally. It can be very handy to automate the publishing process completely on the cloud, so once it is set up correctly, all you have to do next is write the book and push the Rmd source files to GitHub, and your book will always be automatically built and published from the server side.
 

--- a/inst/examples/06-publishing.Rmd
+++ b/inst/examples/06-publishing.Rmd
@@ -29,13 +29,13 @@ You can host your book on GitHub\index{GitHub} for free via GitHub Pages (https:
 
 # create a hidden file .nojekyll
 touch .nojekyll
-# add to git here because won't show up in RStudio
+# add to git here because will not show up in RStudio
 git add .nojekyll
 ```
 
 If you are on Windows, you may not have the `touch` command, and you can create the file in R using `file.create('.nojekyll')`.
 
-One approach is to publish your book as a GitHub Pages site from a `/docs` folder on your `master` branch as described in [GitHub Help.](http://bit.ly/2cvloKV) First, set the output directory of your book to be `/docs` by adding the line `output_dir: "docs"` to the configuration file `_bookdown.yml`. Then, after pushing your changes to GitHub, go to your repository's settings and under "GitHub Pages" change the "Source" to be "master branch /docs folder". In this case the `.nojekyll` file has to be in the `/docs` folder. 
+One approach is to publish your book as a GitHub Pages site from a `/docs` folder on your `master` branch as described in [GitHub Help.](http://bit.ly/2cvloKV) First, set the output directory of your book to be `/docs` by adding the line `output_dir: "docs"` to the configuration file `_bookdown.yml`. Then, after pushing your changes to GitHub, go to your repository's settings and under "GitHub Pages" change the "Source" to be "master branch /docs folder". In this case, the `.nojekyll` file has to be in the `/docs` folder. 
 
 An alternative approach is to create a `gh-pages` branch in your repository, build the book, put the HTML output (including all external resources like images, CSS, and JavaScript files) in this branch, and push the branch to the remote repository. If your book repository does not have the `gh-pages` branch, you may use the following commands to create one:
 


### PR DESCRIPTION
Here is a 2nd try at explaining how .nojekyll fits in with the two different GitHub pages approaches. 