### PR TITLE
fix the bug that multi-byte character in R code throw error

### DIFF
--- a/inst/scripts/render_one.R
+++ b/inst/scripts/render_one.R
@@ -4,7 +4,7 @@
 local({
   args = commandArgs(TRUE)
   out = do.call(
-    rmarkdown::render, c(args[1], readRDS(args[2]), list(run_pandoc = FALSE, encoding = 'UTF-8'))
+    rmarkdown::render, c(args[1], readRDS(args[2]), list(run_pandoc = FALSE))
   )
   out_expected = bookdown:::with_ext(args[1], '.md')
   if (out != out_expected) {


### PR DESCRIPTION
# update

I give up. If anybody asks you this question, you just tell them to switch to GNU @yihui 

#  overview

Even all Rmd files are encoded in UTF-8, `render_book()` still fails if there is multi-byte character in R code on Windows 10. (I test it using the Simplified Chinese Edition)

# `index.Rmd`

    ---
    title: "minimal example for multi-byte character in R code"
    ---

    Edited From https://github.com/hadley/r4ds 's `workflow-basics.Rmd` `## Practice`

    multi-byte character in text: ı

    ```{r include=FALSE, cache=FALSE}
    knitr::opts_chunk$set(cache = TRUE)
    ```

    ```{r, error = TRUE}
    my_variable <- 10
    my_varıable  # multi-byte character in code
    ```

# `render_book()` fails

    > bookdown::render_book('.', bookdown::gitbook(), new_session = F);

    processing file: _main.Rmd
    ...
    Quitting from lines 14-16 (_main.Rmd) 
    Error in parse(text = code, keep.source = FALSE) : 
    <text>:2:14: unexpected '>'
    1: my_variable <- 10
    2: my_var<U+0131>
                    ^

    Please delete _main.Rmd after you finish debugging the error.



    > bookdown::render_book('.', bookdown::gitbook(), new_session = T);

    processing file: index.Rmd
    ...
    Quitting from lines 14-16 (index.Rmd) 
    Error in parse(text = code, keep.source = FALSE) : 
    <text>:2:14: unexpected '>'
    1: my_variable <- 10
    2: my_var<U+0131>
                    ^
    Calls: local ... block_exec -> %n% -> <Anonymous> -> parse_only -> parse

    Execution halted
    Error in Rscript_render(f, render_args, render_meta) : 
    Failed to compile index.Rmd
    In addition: Warning message:
    running command '"W:/program/R-3.4.1/bin/x64/Rscript" "W:/program/lib/R/bookdown/scripts/render_one.R" "index.Rmd" ".\render31342f37620a.rds" "_main.rds"' had status 1 

# explain

You may refer https://github.com/viking/r-yaml/issues/38 for more information. I have send e-mails to you about this issue @yihui 

To produce desired output, one must render Rmarkdown files to pandoc's markdown files with `encoding = "native.enc"` (`options('encoding')` gives `"native.enc"`), then render pandoc's markdown files to gitbook with `encoding = "UTF-8"`. like this:

![image](https://user-images.githubusercontent.com/15871952/29001581-da416294-7ac0-11e7-8481-aab000ecf273.png)

I don't know how to write the code of `render_cur_session()`, but the basic ideas is the same.