### PR TITLE
Allow alternative config files

### DIFF
--- a/R/ebook.R
+++ b/R/ebook.R
@@ -249,16 +249,17 @@ calibre = function(input, output, options = '') {
 #' @param exec The path to the executable \command{kindlegen}, which can be
 #'   downloaded from
 #'   \url{http://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211}.
+#' @param config_file File name (inc. relative path if required) of the configuration file for the render. The default is \file{_bookdown.yml}.
 #' @return The path of the \file{.mobi} file if the conversion is successful.
 #' @export
-kindlegen = function(epub, exec = Sys.which('kindlegen')) {
+kindlegen = function(epub, exec = Sys.which('kindlegen'), config_file="_bookdown.yml") {
   if (exec == '') stop(
     'Cannot find the executable KindleGen. You may download it from ',
     'http://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211'
   )
   if (missing(epub)) {
     on.exit(opts$restore(), add = TRUE)
-    config = load_config()
+    config = load_config(config_file)
     main = with_ext(book_filename(config), 'epub')
     epub = file.path(output_dirname(NULL, config), main)
   }

--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -80,7 +80,7 @@ gitbook_dependency = function() {
 
 gitbook_page = function(
   head, toc, chapter, link_prev, link_next, rmd_cur, html_cur, foot,
-  config, split_by
+  config, split_by, config_file='_bookdown.yml'
 ) {
   toc = gitbook_toc(toc, rmd_cur, config[['toc']])
 
@@ -128,7 +128,7 @@ gitbook_page = function(
   if (length(rmd_cur) && is.list(config$edit))
     config$edit$link = sprintf(config$edit$link, rmd_cur)
 
-  config$download = download_filenames(config)
+  config$download = download_filenames(config, config_file)
 
   foot = sub('<!--bookdown:config-->', gitbook_config(config), foot)
 
@@ -216,8 +216,8 @@ gitbook_config = function(config = list()) {
 }
 
 # infer pdf/epub/mobi filenames from the book filename
-download_filenames = function(config) {
-  if (length(exts <- load_config()[['download']]) == 0) exts = config$download
+download_filenames = function(config, config_file='_bookdown.yml') {
+  if (length(exts <- load_config(config_file)[['download']]) == 0) exts = config$download
   if (identical(exts, FALSE)) return()
   if (is.list(exts)) return(exts)  # I assume you are doing it correctly
   if ((n <- length(grep('[.]', exts))) > 0) {

--- a/R/html.R
+++ b/R/html.R
@@ -406,8 +406,8 @@ edit_link = function(target) {
   button_link(sprintf(setting$link, target), setting$text)
 }
 
-edit_setting = function(config) {
-  config_default = load_config()[['edit']]
+edit_setting = function(config, config_file='_bookdown.yml') {
+  config_default = load_config(config_file)[['edit']]
   if (missing(config) || is.null(config)) config = config_default
   if (is.null(config)) return()
   if (is.character(config)) config = list(link = config, text = NULL)
@@ -578,8 +578,8 @@ label_prefix = function(type, dict = label_names) i18n('label', type, dict)
 ui_names = list(edit = 'Edit', chapter_name = '')
 ui_language = function(key, dict = ui_names) i18n('ui', key, ui_names)
 
-i18n = function(group, key, dict = list()) {
-  labels = load_config()[['language']][[group]]
+i18n = function(group, key, dict = list(), config_file='_bookdown.yml') {
+  labels = load_config(config_file)[['language']][[group]]
   if (is.null(labels[[key]])) dict[[key]] else labels[[key]]
 }
 
@@ -680,8 +680,8 @@ add_toc_ids = function(toc) {
   toc
 }
 
-add_chapter_prefix = function(content) {
-  config = load_config()
+add_chapter_prefix = function(content, config_file='_bookdown.yml') {
+  config = load_config(config_file)
   chapter_name = config[['chapter_name']] %n% ui_language('chapter_name')
   if (is.null(chapter_name) || identical(chapter_name, '')) return(content)
   chapter_fun = if (is.character(chapter_name)) {

--- a/R/render.R
+++ b/R/render.R
@@ -24,7 +24,7 @@
 #'   \file{_book} will be used).
 #' @param new_session Whether to use new R sessions to compile individual Rmd
 #'   files (if not provided, the value of the \code{new_session} option in
-#'   \file{_bookdown.yml} is used; if this is also not provided,
+#'   \file{_bookdown.yml} (or the non-default file) is used; if this is also not provided,
 #'   \code{new_session = FALSE}).
 #' @param preview Whether to render and preview the input files specified by the
 #'   \code{input} argument. Previewing a certain chapter may save compilation
@@ -32,11 +32,12 @@
 #'   accurate (e.g. cross-references to other chapters will not work).
 #' @param encoding Ignored. The character encoding of all input files is
 #'   supposed to be UTF-8.
+#' @param config_file File name (inc. relative path if required) of the configuration file for the render. The default is \file{_bookdown.yml}.
 #' @export
 render_book = function(
   input, output_format = NULL, ..., clean = TRUE, envir = parent.frame(),
   clean_envir = !interactive(), output_dir = NULL, new_session = NA,
-  preview = FALSE, encoding = 'UTF-8'
+  preview = FALSE, encoding = 'UTF-8', config_file='_bookdown.yml'
 ) {
 
   verify_rstudio_version()
@@ -60,7 +61,7 @@ render_book = function(
   if (clean_envir) rm(list = ls(envir, all.names = TRUE), envir = envir)
 
   on.exit(opts$restore(), add = TRUE)
-  config = load_config()  # configurations in _bookdown.yml
+  config = load_config(config_file)  # configurations in _bookdown.yml (by default)
   output_dir = output_dirname(output_dir, config)
   on.exit(clean_empty_dir(output_dir), add = TRUE)
   # store output directory and the initial input Rmd name
@@ -209,8 +210,9 @@ render_new_session = function(files, main, config, output_format, clean, envir, 
 #'   force this function to delete files. You are recommended to take a look at
 #'   the list of files at least once before actually deleting them, i.e. run
 #'   \code{clean_book(FALSE)} before \code{clean_book(TRUE)}.
+#' @param config_file File name (inc. relative path if required) of the configuration file for the render. The default is \file{_bookdown.yml}.
 #' @export
-clean_book = function(clean = getOption('bookdown.clean_book', FALSE)) {
+clean_book = function(clean = getOption('bookdown.clean_book', FALSE), config_file='_bookdown.yml') {
   r = '_(files|cache)$'
   one = with_ext(book_filename(), '')  # the main book file
   src = with_ext(source_files(all = TRUE), '')  # input documents
@@ -219,7 +221,7 @@ clean_book = function(clean = getOption('bookdown.clean_book', FALSE)) {
   out = out[gsub(r, '', out) %in% c(src, one)]  # output dirs generated from src names
   out = c(out, output_dirname(NULL, create = FALSE))  # output directory
   out = c(out, with_ext(one, c('bbl', 'html', 'tex', 'rds')))  # aux files for main file
-  out = c(out, load_config()[['clean']])  # extra files specified in _bookdown.yml
+  out = c(out, load_config(config_file)[['clean']])  # extra files specified in _bookdown.yml
   out = sort(unique(out))
   if (length(out) == 0) return(invisible())
   if (clean) unlink(out, recursive = TRUE) else {

--- a/R/site.R
+++ b/R/site.R
@@ -3,10 +3,12 @@
 #'
 #' Implementation of custom R Markdown site generator for bookdown.
 #'
+#' @param config_file File name (inc. relative path if required) of the configuration file for the render. The default is \file{_bookdown.yml}.
+#'
 #' @inheritParams rmarkdown::render_site
 #'
 #' @export
-bookdown_site = function(input, ...) {
+bookdown_site = function(input, config_file='_bookdown.yml', ...) {
 
   on.exit(opts$restore(), add = TRUE)
 
@@ -15,7 +17,7 @@ bookdown_site = function(input, ...) {
   on.exit(setwd(oldwd), add = TRUE)
 
   # load the config for the input directory
-  config = load_config()
+  config = load_config(config_file)
 
   # get the name from the config (default to the directory name
   # if there is no name in the config)

--- a/R/utils.R
+++ b/R/utils.R
@@ -76,21 +76,23 @@ get_base_format = function(format) {
   format
 }
 
-load_config = function() {
-  if (length(opts$get('config')) == 0 && file.exists('_bookdown.yml')) {
+load_config = function(config_file='_bookdown.yml') {
+  if (length(opts$get('config')) == 0 && file.exists(config_file)) {
     # store the book config
-    opts$set(config = yaml::yaml.load_file('_bookdown.yml'))
+    opts$set(config = yaml::yaml.load_file(config_file))
   }
   opts$get('config')
 }
 
-book_filename = function(config = load_config(), fallback = TRUE) {
+book_filename = function(config_file = '_bookdown.yml', fallback = TRUE) {
+  config = load_config(config_file)
   if (is.character(config[['book_filename']])) {
     config[['book_filename']][1]
   } else if (fallback) '_main'
 }
 
-source_files = function(format = NULL, config = load_config(), all = FALSE) {
+source_files = function(format = NULL, config_file = '_bookdown.yml', all = FALSE) {
+  config = load_config(config_file)
   # a list of Rmd chapters
   files = list.files(
     '.', '[.]Rmd$', ignore.case = TRUE, recursive = isTRUE(config[['rmd_subdir']])
@@ -109,7 +111,8 @@ source_files = function(format = NULL, config = load_config(), all = FALSE) {
   check_special_chars(files)
 }
 
-output_dirname = function(dir, config = load_config(), create = TRUE) {
+output_dirname = function(dir, config_file = '_bookdown.yml', create = TRUE) {
+  config = load_config(config_file)
   if (is.null(dir)) {
     dir2 = config[['output_dir']]
     if (!is.null(dir2)) dir = dir2
@@ -292,9 +295,10 @@ local_resources = function(x) {
 #'   the book directory.
 #' @param ... Other arguments passed to \code{servr::\link[servr]{httw}()} (not
 #'   including the \code{handler} argument, which has been set internally).
+#' @param config_file File name (inc. relative path if required) of the configuration file for the render. The default is \file{_bookdown.yml}.
 #' @export
 serve_book = function(
-  dir = '.', output_dir = '_book', preview = TRUE, in_session = TRUE, ...
+  dir = '.', output_dir = '_book', preview = TRUE, in_session = TRUE, config_file = 'bookdown.yml', ...
 ) {
   # when this function is called via the RStudio addin, use the dir of the
   # current active document
@@ -309,7 +313,7 @@ serve_book = function(
   owd = setwd(dir); on.exit(setwd(owd), add = TRUE)
   if (missing(output_dir) || is.null(output_dir)) {
     on.exit(opts$restore(), add = TRUE)
-    output_dir = load_config()[['output_dir']]
+    output_dir = load_config(config_file)[['output_dir']]
   }
   if (is.null(output_dir)) output_dir = '_book'
   if (missing(preview)) preview = getOption('bookdown.preview', TRUE)

--- a/man/bookdown_site.Rd
+++ b/man/bookdown_site.Rd
@@ -4,10 +4,12 @@
 \alias{bookdown_site}
 \title{R Markdown site generator for bookdown}
 \usage{
-bookdown_site(input, ...)
+bookdown_site(input, config_file = "_bookdown.yml", ...)
 }
 \arguments{
 \item{input}{Website directory (or the name of a file within the directory)}
+
+\item{config_file}{File name (inc. relative path if required) of the configuration file for the render. The default is \file{_bookdown.yml}.}
 
 \item{...}{Currently unused}
 }

--- a/man/clean_book.Rd
+++ b/man/clean_book.Rd
@@ -4,7 +4,8 @@
 \alias{clean_book}
 \title{Clean up the output files and directories from the book}
 \usage{
-clean_book(clean = getOption("bookdown.clean_book", FALSE))
+clean_book(clean = getOption("bookdown.clean_book", FALSE),
+  config_file = "_bookdown.yml")
 }
 \arguments{
 \item{clean}{Whether to delete the possible output files. If \code{FALSE},
@@ -13,6 +14,8 @@ deleted. You can set the global option \code{bookdown.clean_book = TRUE} to
 force this function to delete files. You are recommended to take a look at
 the list of files at least once before actually deleting them, i.e. run
 \code{clean_book(FALSE)} before \code{clean_book(TRUE)}.}
+
+\item{config_file}{File name (inc. relative path if required) of the configuration file for the render. The default is \file{_bookdown.yml}.}
 }
 \description{
 After a book is rendered, there will be a series of output files and

--- a/man/epub_book.Rd
+++ b/man/epub_book.Rd
@@ -4,10 +4,11 @@
 \alias{epub_book}
 \title{The EPUB e-book format}
 \usage{
-epub_book(fig_width = 5, fig_height = 4, dev = "png", fig_caption = TRUE, 
-    number_sections = TRUE, toc = FALSE, toc_depth = 3, stylesheet = NULL, 
-    cover_image = NULL, metadata = NULL, chapter_level = 1, epub_version = c("epub3", 
-        "epub"), md_extensions = NULL, pandoc_args = NULL)
+epub_book(fig_width = 5, fig_height = 4, dev = "png",
+  fig_caption = TRUE, number_sections = TRUE, toc = FALSE,
+  toc_depth = 3, stylesheet = NULL, cover_image = NULL, metadata = NULL,
+  chapter_level = 1, epub_version = c("epub3", "epub"),
+  md_extensions = NULL, pandoc_args = NULL)
 }
 \arguments{
 \item{fig_width, fig_height, dev, fig_caption}{Figure options (width, height,

--- a/man/gitbook.Rd
+++ b/man/gitbook.Rd
@@ -4,9 +4,10 @@
 \alias{gitbook}
 \title{The GitBook output format}
 \usage{
-gitbook(fig_caption = TRUE, number_sections = TRUE, self_contained = FALSE, 
-    lib_dir = "libs", ..., split_by = c("chapter", "chapter+number", "section", 
-        "section+number", "rmd", "none"), split_bib = TRUE, config = list())
+gitbook(fig_caption = TRUE, number_sections = TRUE,
+  self_contained = FALSE, lib_dir = "libs", ..., split_by = c("chapter",
+  "chapter+number", "section", "section+number", "rmd", "none"),
+  split_bib = TRUE, config = list())
 }
 \arguments{
 \item{fig_caption, number_sections, self_contained, lib_dir, ...}{Arguments to be

--- a/man/html_chapters.Rd
+++ b/man/html_chapters.Rd
@@ -6,11 +6,11 @@
 \alias{tufte_html_book}
 \title{Build book chapters into separate HTML files}
 \usage{
-html_chapters(toc = TRUE, number_sections = TRUE, fig_caption = TRUE, 
-    lib_dir = "libs", template = bookdown_file("templates/default.html"), 
-    ..., base_format = rmarkdown::html_document, split_bib = TRUE, 
-    page_builder = build_chapter, split_by = c("section+number", "section", 
-        "chapter+number", "chapter", "rmd", "none"))
+html_chapters(toc = TRUE, number_sections = TRUE, fig_caption = TRUE,
+  lib_dir = "libs", template = bookdown_file("templates/default.html"), ...,
+  base_format = rmarkdown::html_document, split_bib = TRUE,
+  page_builder = build_chapter, split_by = c("section+number", "section",
+  "chapter+number", "chapter", "rmd", "none"))
 
 html_book(...)
 

--- a/man/html_document2.Rd
+++ b/man/html_document2.Rd
@@ -10,7 +10,8 @@
 \title{Output formats that allow numbering and cross-referencing
 figures/tables/equations}
 \usage{
-html_document2(..., number_sections = TRUE, base_format = rmarkdown::html_document)
+html_document2(..., number_sections = TRUE,
+  base_format = rmarkdown::html_document)
 
 tufte_html2(..., number_sections = FALSE)
 
@@ -20,7 +21,8 @@ tufte_handout2(...)
 
 tufte_book2(...)
 
-word_document2(fig_caption = TRUE, md_extensions = NULL, pandoc_args = NULL, ...)
+word_document2(fig_caption = TRUE, md_extensions = NULL,
+  pandoc_args = NULL, ...)
 }
 \arguments{
 \item{..., fig_caption, md_extensions, pandoc_args}{Arguments to be passed to a

--- a/man/kindlegen.Rd
+++ b/man/kindlegen.Rd
@@ -4,7 +4,8 @@
 \alias{kindlegen}
 \title{A wrapper function to convert EPUB to the Mobipocket format}
 \usage{
-kindlegen(epub, exec = Sys.which("kindlegen"))
+kindlegen(epub, exec = Sys.which("kindlegen"),
+  config_file = "_bookdown.yml")
 }
 \arguments{
 \item{epub}{The path to a \code{.epub} file (e.g. created from the
@@ -14,6 +15,8 @@ from the book configurations.}
 \item{exec}{The path to the executable \command{kindlegen}, which can be
 downloaded from
 \url{http://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211}.}
+
+\item{config_file}{File name (inc. relative path if required) of the configuration file for the render. The default is \file{_bookdown.yml}.}
 }
 \value{
 The path of the \file{.mobi} file if the conversion is successful.

--- a/man/pdf_book.Rd
+++ b/man/pdf_book.Rd
@@ -4,9 +4,10 @@
 \alias{pdf_book}
 \title{Convert R Markdown to a PDF book}
 \usage{
-pdf_book(toc = TRUE, number_sections = TRUE, fig_caption = TRUE, ..., 
-    base_format = rmarkdown::pdf_document, toc_unnumbered = TRUE, toc_appendix = FALSE, 
-    toc_bib = FALSE, quote_footer = NULL, highlight_bw = FALSE)
+pdf_book(toc = TRUE, number_sections = TRUE, fig_caption = TRUE, ...,
+  base_format = rmarkdown::pdf_document, toc_unnumbered = TRUE,
+  toc_appendix = FALSE, toc_bib = FALSE, quote_footer = NULL,
+  highlight_bw = FALSE)
 }
 \arguments{
 \item{toc, number_sections, fig_caption}{See

--- a/man/publish_book.Rd
+++ b/man/publish_book.Rd
@@ -4,8 +4,8 @@
 \alias{publish_book}
 \title{Publish a book to the web}
 \usage{
-publish_book(name = NULL, account = NULL, server = NULL, render = c("none", "local", 
-    "server"))
+publish_book(name = NULL, account = NULL, server = NULL,
+  render = c("none", "local", "server"))
 }
 \arguments{
 \item{name}{Name of the book (this will be used in the URL path of the

--- a/man/render_book.Rd
+++ b/man/render_book.Rd
@@ -5,9 +5,10 @@
 \alias{preview_chapter}
 \title{Render multiple R Markdown documents into a book}
 \usage{
-render_book(input, output_format = NULL, ..., clean = TRUE, envir = parent.frame(), 
-    clean_envir = !interactive(), output_dir = NULL, new_session = NA, preview = FALSE, 
-    encoding = "UTF-8")
+render_book(input, output_format = NULL, ..., clean = TRUE,
+  envir = parent.frame(), clean_envir = !interactive(), output_dir = NULL,
+  new_session = NA, preview = FALSE, encoding = "UTF-8",
+  config_file = "_bookdown.yml")
 
 preview_chapter(..., envir = parent.frame())
 }
@@ -31,7 +32,7 @@ used (possibly not specified, either, in which case a directory name
 
 \item{new_session}{Whether to use new R sessions to compile individual Rmd
 files (if not provided, the value of the \code{new_session} option in
-\file{_bookdown.yml} is used; if this is also not provided,
+\file{_bookdown.yml} (or the non-default file) is used; if this is also not provided,
 \code{new_session = FALSE}).}
 
 \item{preview}{Whether to render and preview the input files specified by the
@@ -41,6 +42,8 @@ accurate (e.g. cross-references to other chapters will not work).}
 
 \item{encoding}{Ignored. The character encoding of all input files is
 supposed to be UTF-8.}
+
+\item{config_file}{File name (inc. relative path if required) of the configuration file for the render. The default is \file{_bookdown.yml}.}
 }
 \description{
 Render multiple R Markdown files under the current working directory into a

--- a/man/serve_book.Rd
+++ b/man/serve_book.Rd
@@ -4,7 +4,8 @@
 \alias{serve_book}
 \title{Continously preview the HTML output of a book using the \pkg{servr} package}
 \usage{
-serve_book(dir = ".", output_dir = "_book", preview = TRUE, in_session = TRUE, ...)
+serve_book(dir = ".", output_dir = "_book", preview = TRUE,
+  in_session = TRUE, config_file = "bookdown.yml", ...)
 }
 \arguments{
 \item{dir}{The root directory of the book (containing the Rmd source files).}
@@ -18,6 +19,8 @@ whole book; see \code{\link{render_book}()}.}
 \item{in_session}{Whether to compile the book using the current R session, or
 always open a new R session to compile the book whenever changes occur in
 the book directory.}
+
+\item{config_file}{File name (inc. relative path if required) of the configuration file for the render. The default is \file{_bookdown.yml}.}
 
 \item{...}{Other arguments passed to \code{servr::\link[servr]{httw}()} (not
 including the \code{handler} argument, which has been set internally).}


### PR DESCRIPTION
I'd like to be able to have different config files instead of just `_bookdown.yml` - this enables me to have many files like `topicA`, `topicB`, `topic?` and be able to knit these into different books by pointing at different config file. This will help me reduce duplication and improve my ability to programmatically build books.

---
Notes on dev:

- I believe I've been stylistically consistent
- I haven't added any tests for alternative files but did confirm that all existing tests passed
- I'm in the process of completing the contributor agreement