### PR TITLE
Fixes multiline footnote word-spacing issue.

### DIFF
--- a/R/html.R
+++ b/R/html.R
@@ -847,7 +847,7 @@ parse_footnotes = function(x) {
   j = min(j[j > i])
   n = length(x)
   r = '<li id="fn([0-9]+)"><p>.+?<a href="#fnref\\1"[^>]*?>.</a></p></li>'
-  s = paste(x[i:n], collapse = '')
+  s = paste(x[i:n], collapse = ' ')
   items = unlist(regmatches(s, gregexpr(r, s)))
   list(items = setNames(items, gsub(r, 'fn\\1', items)), range = i:j)
 }

--- a/R/html.R
+++ b/R/html.R
@@ -847,7 +847,7 @@ parse_footnotes = function(x) {
   j = min(j[j > i])
   n = length(x)
   r = '<li id="fn([0-9]+)"><p>.+?<a href="#fnref\\1"[^>]*?>.</a></p></li>'
-  s = paste(x[i:n], collapse = ' ')
+  s = paste(x[i:n], collapse = '\n')
   items = unlist(regmatches(s, gregexpr(r, s)))
   list(items = setNames(items, gsub(r, 'fn\\1', items)), range = i:j)
 }


### PR DESCRIPTION
Before the change, multiline footnote is not handled properly.  Consider the following minimal example:
```
---
title: "A Book"
author: "Frida Gomam"
site: bookdown::bookdown_site
documentclass: book
output:
  bookdown::gitbook: default
  bookdown::pdf_book: default
---

# Test {-}

Footnote test.^[Multiline
footnote
should
be
allowed]
```
Before the change, the entire footnote appears as one single word:
<img width="308" alt="screen shot 2017-12-30 at 5 20 31 am" src="https://user-images.githubusercontent.com/28999218/34453371-958c333a-ed21-11e7-8d57-87d8272ee2a5.png">

With the change, the footnote appears properly:
<img width="346" alt="screen shot 2017-12-30 at 5 21 16 am" src="https://user-images.githubusercontent.com/28999218/34453377-a20b7580-ed21-11e7-9952-4a6380200386.png">

