### PR TITLE
single quotes for the URL (#162)

### DIFF
--- a/inst/examples/03-formats.Rmd
+++ b/inst/examples/03-formats.Rmd
@@ -190,7 +190,7 @@ Below we show some sample YAML metadata (again, please note that these are _top-
 title: "An Awesome Book"
 author: "John Smith"
 description: "This book introduces the ABC theory, and ..."
-url: "https\://bookdown.org/john/awesome/"
+url: 'https\://bookdown.org/john/awesome/'
 github-repo: "john/awesome"
 cover-image: "images/cover.png"
 apple-touch-icon: "touch-icon.png"


### PR DESCRIPTION
In reference to #162 section 3.1.1. of the 'bookdown' book still uses double quotes for the 'url' YAML metadata tag. Since pandoc is apparantly still missing the feature to handle double quotes for this very tag, copying the code from the book still results in an unknown escape character error.