### PR TITLE
Document that \frontmatter goes into preamble.tex

### DIFF
--- a/inst/examples/06-publishing.Rmd
+++ b/inst/examples/06-publishing.Rmd
@@ -205,12 +205,12 @@ bookdown::pdf_book:
   highlight_bw: yes
 ```
 
-All preamble settings we mentioned above are in the file `latex/preamble.tex`. In `latex/before_body.tex`, we inserted a few blank pages required by the publisher, wrote the dedication page, and specified that the front matter starts:
+All preamble settings we mentioned above are in the file `latex/preamble.tex`, where we also specified that the front matter starts:
 
 ```latex
 \frontmatter
 ```
-
+In `latex/before_body.tex`, we inserted a few blank pages required by the publisher and wrote the dedication page.
 Before the first chapter of the book, we inserted
 
 ```latex


### PR DESCRIPTION
This change brings the documentation in line with the implementation. It is important to have `\frontmatter` in `preamble.tex` and not in `before_body.tex`. Otherwise the title page would not be part of the front matter and page numbering would be reset *after* it. 

Motivated by this SO question: https://stackoverflow.com/questions/43711029/page-numbering-in-r-bookdown/