### PR TITLE
Allow `rmd_subdir` to be either a bool or list of subdirectories.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Authors@R: c(
     person("David", "Shuman", role = "ctb"),
     person("Dean", "Attali", role = "ctb"),
     person("Drew", "Tyre", role = "ctb"),
-    person("Ellis", "Valentiner", role = "ctb")
+    person("Ellis", "Valentiner", role = "ctb"),
     person("Frans", "van Dunne", role = "ctb"),
     person("Hadley", "Wickham", role = "ctb"),
     person("Jeff", "Allen", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ Authors@R: c(
     person("David", "Shuman", role = "ctb"),
     person("Dean", "Attali", role = "ctb"),
     person("Drew", "Tyre", role = "ctb"),
+    person("Ellis", "Valentiner", role = "ctb")
     person("Frans", "van Dunne", role = "ctb"),
     person("Hadley", "Wickham", role = "ctb"),
     person("Jeff", "Allen", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Added Conjecture to the list of theorem environments.
 
+- In addition to `rmd_subdir: true`, which searches all subdirectories, you can now provide a list of subdirectories to be recursively searched (#242).
+
 # CHANGES IN bookdown VERSION 0.7
 
 ## MINOR CHANGES

--- a/R/utils.R
+++ b/R/utils.R
@@ -58,9 +58,20 @@ book_filename = function(config = load_config(), fallback = TRUE) {
 
 source_files = function(format = NULL, config = load_config(), all = FALSE) {
   # a list of Rmd chapters
-  files = list.files(
-    '.', '[.]Rmd$', ignore.case = TRUE, recursive = isTRUE(config[['rmd_subdir']])
-  )
+  if (isTRUE(config[['rmd_subdir']])) {
+    files = list.files(
+      '.', '[.]Rmd$', ignore.case = TRUE, recursive = TRUE
+      )
+  } else if (is.character(config[['rmd_subdir']])) {
+    files = list.files(
+      config[['rmd_subdir']], '[.]Rmd$', ignore.case = TRUE, recursive = TRUE,
+      full.names = TRUE
+    )
+  } else {
+    files = list.files(
+      '.', '[.]Rmd$', ignore.case = TRUE
+    )
+  }
   if (length(config[['rmd_files']]) > 0) {
     files = config[['rmd_files']]
     if (is.list(files)) {

--- a/inst/examples/04-customization.Rmd
+++ b/inst/examples/04-customization.Rmd
@@ -202,7 +202,7 @@ We have mentioned `rmd_files` in Section \@ref(usage), and there are more (optio
 - `before_chapter_script`: one or multiple R scripts to be executed before each chapter, e.g., you may want to clear the workspace before compiling each chapter, in which case you can use `rm(list = ls(all = TRUE))` in the R script.
 - `after_chapter_script`: similar to `before_chapter_script`, and the R script is executed after each chapter.
 - `edit`: a link that collaborators can click to edit the Rmd source document of the current page; this was designed primarily for GitHub repositories, since it is easy to edit arbitrary plain-text files on GitHub even in other people's repositories (if you do not have write access to the repository, GitHub will automatically fork it and let you submit a pull request after you finish editing the file). This link should have `%s` in it, which will be substituted by the actual Rmd filename for each page.
-- `rmd_subdir`: whether to search for book source Rmd files in subdirectories (by default, only the root directory is searched).
+- `rmd_subdir`: whether to search for book source Rmd files in subdirectories (by default, only the root directory is searched). If you want to search for book source Rmd files in a subset of subdirectories, you can provide a list of subdirectories to be recursively searched.
 - `output_dir`: the output directory of the book (`_book` by default); this setting is read and used by `render_book()`.
 - `clean`: a vector of files and directories to be cleaned by the `clean_book()` function.
 


### PR DESCRIPTION
**Description:**

If `rmd_subdir` is true then bookdown searches for files *recursively* from the project root directory. If `rmd_subdir` is a list of subdirectories then bookdown search for files *recursively* from each subdirectory.

I have submitted the individual contributor agreement and welcome feedback on this pull request.

Fixes #242