### PR TITLE
allow custom pandoc templates for gitbook and epub

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,6 +36,7 @@ Authors@R: c(
     person("Peter", "Hickey", role = "ctb"),
     person("Sahir", "Bhatnagar", role = "ctb"),
     person("Steve", "Simpson", role = "ctb"),
+    person("Thierry", "Onkelinx", role = "ctb", comment = c(ORCID = "0000-0001-8804-4216")),
     person("Vincent", "Fulco", role = "ctb"),
     person("Yixuan", "Qiu", role = "ctb"),
     person("Zhuoer", "Dong", role = "ctb"),

--- a/R/ebook.R
+++ b/R/ebook.R
@@ -15,6 +15,7 @@
 #' @param epub_version Whether to use version 3 or 2 of EPUB.
 #' @param md_extensions A character string of Pandoc Markdown extensions.
 #' @param pandoc_args A vector of additional Pandoc arguments.
+#' @inheritParams html_chapters
 #' @note Figure/table numbers cannot be generated if sections are not numbered
 #'   (\code{number_sections = FALSE}).
 #' @export
@@ -22,9 +23,9 @@ epub_book = function(
   fig_width = 5, fig_height = 4, dev = 'png', fig_caption = TRUE,
   number_sections = TRUE, toc = FALSE, toc_depth = 3, stylesheet = NULL,
   cover_image = NULL, metadata = NULL, chapter_level = 1,
-  epub_version = c('epub3', 'epub'), md_extensions = NULL, pandoc_args = NULL
+  epub_version = c('epub3', 'epub'), md_extensions = NULL, pandoc_args = NULL,
+  template
 ) {
-
   epub_version = match.arg(epub_version)
   args = c(
     pandoc_args,
@@ -33,6 +34,7 @@ epub_book = function(
     if (!missing(toc_depth)) c('--toc-depth', toc_depth),
     if (!is.null(cover_image)) c('--epub-cover-image', cover_image),
     if (!is.null(metadata)) c('--epub-metadata', metadata),
+    if (!missing(template)) c('--template', template),
     if (!missing(chapter_level)) c('--epub-chapter-level', chapter_level)
   )
   if (is.null(stylesheet)) css = NULL else {

--- a/R/ebook.R
+++ b/R/ebook.R
@@ -15,7 +15,7 @@
 #' @param epub_version Whether to use version 3 or 2 of EPUB.
 #' @param md_extensions A character string of Pandoc Markdown extensions.
 #' @param pandoc_args A vector of additional Pandoc arguments.
-#' @inheritParams html_chapters
+#' @param template Pandoc template to use for rendering. Pass "default" to use use pandoc's built-in template; pass a path to use a custom template that you've created. The default pandoc template should be sufficient for most use cases. In case you want to develop a custom template, we highly recommend to start from the \href{https://github.com/jgm/pandoc-templates/blob/master/default.epub3}{default pandoc template}.
 #' @note Figure/table numbers cannot be generated if sections are not numbered
 #'   (\code{number_sections = FALSE}).
 #' @export
@@ -24,7 +24,7 @@ epub_book = function(
   number_sections = TRUE, toc = FALSE, toc_depth = 3, stylesheet = NULL,
   cover_image = NULL, metadata = NULL, chapter_level = 1,
   epub_version = c('epub3', 'epub'), md_extensions = NULL, pandoc_args = NULL,
-  template
+  template = 'default'
 ) {
   epub_version = match.arg(epub_version)
   args = c(
@@ -34,7 +34,7 @@ epub_book = function(
     if (!missing(toc_depth)) c('--toc-depth', toc_depth),
     if (!is.null(cover_image)) c('--epub-cover-image', cover_image),
     if (!is.null(metadata)) c('--epub-metadata', metadata),
-    if (!missing(template)) c('--template', template),
+    if (!identical(template, 'default')) c('--template', template),
     if (!missing(chapter_level)) c('--epub-chapter-level', chapter_level)
   )
   if (is.null(stylesheet)) css = NULL else {

--- a/R/ebook.R
+++ b/R/ebook.R
@@ -15,7 +15,12 @@
 #' @param epub_version Whether to use version 3 or 2 of EPUB.
 #' @param md_extensions A character string of Pandoc Markdown extensions.
 #' @param pandoc_args A vector of additional Pandoc arguments.
-#' @param template Pandoc template to use for rendering. Pass "default" to use use pandoc's built-in template; pass a path to use a custom template that you've created. The default pandoc template should be sufficient for most use cases. In case you want to develop a custom template, we highly recommend to start from the \href{https://github.com/jgm/pandoc-templates/blob/master/default.epub3}{default pandoc template}.
+#' @param template Pandoc template to use for rendering. Pass \code{"default"}
+#'   to use Pandoc's built-in template; pass a path to use a custom template.
+#'   The default pandoc template should be sufficient for most use cases. In
+#'   case you want to develop a custom template, we highly recommend to start
+#'   from the default EPUB templates at
+#'   \url{https://github.com/jgm/pandoc-templates/}.
 #' @note Figure/table numbers cannot be generated if sections are not numbered
 #'   (\code{number_sections = FALSE}).
 #' @export

--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -6,12 +6,13 @@
 #' @param fig_caption,number_sections,self_contained,lib_dir,pandoc_args ...
 #'   Arguments to be passed to \code{rmarkdown::\link{html_document}()}
 #'   (\code{...} not including \code{toc}, and \code{theme}).
+#' @param template Pandoc template to use for rendering. Pass "default" to use the rmarkdown package default template; pass a path to use a custom template that you've created. The default template should be sufficient for most use cases. In case you want to develop a custom template, we highly recommend to start from the \href{https://github.com/rstudio/bookdown/blob/master/inst/templates/gitbook.html}{rmarkdown package default template}.
 #' @param config A list of configuration options for the gitbook style, such as
 #'   the font/theme settings.
 #' @export
 gitbook = function(
   fig_caption = TRUE, number_sections = TRUE, self_contained = FALSE,
-  lib_dir = 'libs', pandoc_args = NULL, ..., template = bookdown_file('templates', 'gitbook.html'),
+  lib_dir = 'libs', pandoc_args = NULL, ..., template = 'default',
   split_by = c('chapter', 'chapter+number', 'section', 'section+number', 'rmd', 'none'),
   split_bib = TRUE, config = list()
 ) {
@@ -21,6 +22,9 @@ gitbook = function(
     )
   }
   gb_config = config
+  if (identical(template, 'default')) {
+    template <- bookdown_file('templates', 'gitbook.html')
+  }
   config = html_document2(
     toc = TRUE, number_sections = number_sections, fig_caption = fig_caption,
     self_contained = self_contained, lib_dir = lib_dir, theme = NULL,

--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -5,13 +5,13 @@
 #' @inheritParams html_chapters
 #' @param fig_caption,number_sections,self_contained,lib_dir,pandoc_args ...
 #'   Arguments to be passed to \code{rmarkdown::\link{html_document}()}
-#'   (\code{...} not including \code{toc}, \code{theme}, and \code{template}).
+#'   (\code{...} not including \code{toc}, and \code{theme}).
 #' @param config A list of configuration options for the gitbook style, such as
 #'   the font/theme settings.
 #' @export
 gitbook = function(
   fig_caption = TRUE, number_sections = TRUE, self_contained = FALSE,
-  lib_dir = 'libs', pandoc_args = NULL, ...,
+  lib_dir = 'libs', pandoc_args = NULL, ..., template = bookdown_file('templates', 'gitbook.html'),
   split_by = c('chapter', 'chapter+number', 'section', 'section+number', 'rmd', 'none'),
   split_bib = TRUE, config = list()
 ) {
@@ -24,7 +24,7 @@ gitbook = function(
   config = html_document2(
     toc = TRUE, number_sections = number_sections, fig_caption = fig_caption,
     self_contained = self_contained, lib_dir = lib_dir, theme = NULL,
-    template = bookdown_file('templates', 'gitbook.html'),
+    template = template,
     pandoc_args = pandoc_args2(pandoc_args), ...
   )
   split_by = match.arg(split_by)

--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -29,7 +29,7 @@ gitbook = function(
   }
   gb_config = config
   if (identical(template, 'default')) {
-    template <- bookdown_file('templates', 'gitbook.html')
+    template = bookdown_file('templates', 'gitbook.html')
   }
   config = html_document2(
     toc = TRUE, number_sections = number_sections, fig_caption = fig_caption,

--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -34,8 +34,7 @@ gitbook = function(
   config = html_document2(
     toc = TRUE, number_sections = number_sections, fig_caption = fig_caption,
     self_contained = self_contained, lib_dir = lib_dir, theme = NULL,
-    template = template,
-    pandoc_args = pandoc_args2(pandoc_args), ...
+    template = template, pandoc_args = pandoc_args2(pandoc_args), ...
   )
   split_by = match.arg(split_by)
   post = config$post_processor  # in case a post processor have been defined

--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -6,7 +6,13 @@
 #' @param fig_caption,number_sections,self_contained,lib_dir,pandoc_args ...
 #'   Arguments to be passed to \code{rmarkdown::\link{html_document}()}
 #'   (\code{...} not including \code{toc}, and \code{theme}).
-#' @param template Pandoc template to use for rendering. Pass "default" to use the rmarkdown package default template; pass a path to use a custom template that you've created. The default template should be sufficient for most use cases. In case you want to develop a custom template, we highly recommend to start from the \href{https://github.com/rstudio/bookdown/blob/master/inst/templates/gitbook.html}{rmarkdown package default template}.
+#' @param template Pandoc template to use for rendering. Pass "default" to use
+#'   the bookdown default template; pass a path to use a custom template that
+#'   you have created. The default template should be sufficient for most use
+#'   cases. In case you want to develop a custom template, we highly recommend
+#'   to start from
+#'   \url{https://github.com/rstudio/bookdown/blob/master/inst/templates/gitbook.html}.
+#'
 #' @param config A list of configuration options for the gitbook style, such as
 #'   the font/theme settings.
 #' @export

--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -6,11 +6,11 @@
 #' @param fig_caption,number_sections,self_contained,lib_dir,pandoc_args ...
 #'   Arguments to be passed to \code{rmarkdown::\link{html_document}()}
 #'   (\code{...} not including \code{toc}, and \code{theme}).
-#' @param template Pandoc template to use for rendering. Pass "default" to use
-#'   the bookdown default template; pass a path to use a custom template that
-#'   you have created. The default template should be sufficient for most use
-#'   cases. In case you want to develop a custom template, we highly recommend
-#'   to start from
+#' @param template Pandoc template to use for rendering. Pass \code{"default"}
+#'   to use the bookdown default template; pass a path to use a custom template.
+#'   The default template should be sufficient for most use cases. In case you
+#'   want to develop a custom template, we highly recommend to start from the
+#'   default template:
 #'   \url{https://github.com/rstudio/bookdown/blob/master/inst/templates/gitbook.html}.
 #'
 #' @param config A list of configuration options for the gitbook style, such as

--- a/man/epub_book.Rd
+++ b/man/epub_book.Rd
@@ -7,7 +7,7 @@
 epub_book(fig_width = 5, fig_height = 4, dev = "png", fig_caption = TRUE, 
     number_sections = TRUE, toc = FALSE, toc_depth = 3, stylesheet = NULL, 
     cover_image = NULL, metadata = NULL, chapter_level = 1, epub_version = c("epub3", 
-        "epub"), md_extensions = NULL, pandoc_args = NULL, template)
+        "epub"), md_extensions = NULL, pandoc_args = NULL, template = "default")
 }
 \arguments{
 \item{fig_width, fig_height, dev, fig_caption}{Figure options (width, height,
@@ -33,10 +33,7 @@ applied to the eBook.}
 
 \item{pandoc_args}{A vector of additional Pandoc arguments.}
 
-\item{template}{See
-\code{rmarkdown::\link{html_document}},
-\code{tufte::\link[tufte]{tufte_html}}, or the documentation of the
-\code{base_format} function.}
+\item{template}{Pandoc template to use for rendering. Pass "default" to use use pandoc's built-in template; pass a path to use a custom template that you've created. The default pandoc template should be sufficient for most use cases. In case you want to develop a custom template, we highly recommend to start from the \href{https://github.com/jgm/pandoc-templates/blob/master/default.epub3}{default pandoc template}.}
 }
 \description{
 Convert a book to the EPUB format, which is is an e-book format supported by

--- a/man/epub_book.Rd
+++ b/man/epub_book.Rd
@@ -7,7 +7,7 @@
 epub_book(fig_width = 5, fig_height = 4, dev = "png", fig_caption = TRUE, 
     number_sections = TRUE, toc = FALSE, toc_depth = 3, stylesheet = NULL, 
     cover_image = NULL, metadata = NULL, chapter_level = 1, epub_version = c("epub3", 
-        "epub"), md_extensions = NULL, pandoc_args = NULL)
+        "epub"), md_extensions = NULL, pandoc_args = NULL, template)
 }
 \arguments{
 \item{fig_width, fig_height, dev, fig_caption}{Figure options (width, height,
@@ -32,6 +32,11 @@ applied to the eBook.}
 \item{md_extensions}{A character string of Pandoc Markdown extensions.}
 
 \item{pandoc_args}{A vector of additional Pandoc arguments.}
+
+\item{template}{See
+\code{rmarkdown::\link{html_document}},
+\code{tufte::\link[tufte]{tufte_html}}, or the documentation of the
+\code{base_format} function.}
 }
 \description{
 Convert a book to the EPUB format, which is is an e-book format supported by

--- a/man/epub_book.Rd
+++ b/man/epub_book.Rd
@@ -33,7 +33,12 @@ applied to the eBook.}
 
 \item{pandoc_args}{A vector of additional Pandoc arguments.}
 
-\item{template}{Pandoc template to use for rendering. Pass "default" to use use pandoc's built-in template; pass a path to use a custom template that you've created. The default pandoc template should be sufficient for most use cases. In case you want to develop a custom template, we highly recommend to start from the \href{https://github.com/jgm/pandoc-templates/blob/master/default.epub3}{default pandoc template}.}
+\item{template}{Pandoc template to use for rendering. Pass \code{"default"}
+to use Pandoc's built-in template; pass a path to use a custom template.
+The default pandoc template should be sufficient for most use cases. In
+case you want to develop a custom template, we highly recommend to start
+from the default EPUB templates at
+\url{https://github.com/jgm/pandoc-templates/}.}
 }
 \description{
 Convert a book to the EPUB format, which is is an e-book format supported by

--- a/man/gitbook.Rd
+++ b/man/gitbook.Rd
@@ -18,7 +18,12 @@ Arguments to be passed to \code{rmarkdown::\link{html_document}()}
 \code{html_book()} and \code{tufte_html_book()}, \code{...} is passed to
 \code{html_chapters()}.}
 
-\item{template}{Pandoc template to use for rendering. Pass "default" to use the rmarkdown package default template; pass a path to use a custom template that you've created. The default template should be sufficient for most use cases. In case you want to develop a custom template, we highly recommend to start from the \href{https://github.com/rstudio/bookdown/blob/master/inst/templates/gitbook.html}{rmarkdown package default template}.}
+\item{template}{Pandoc template to use for rendering. Pass \code{"default"}
+to use the bookdown default template; pass a path to use a custom template.
+The default template should be sufficient for most use cases. In case you
+want to develop a custom template, we highly recommend to start from the
+default template:
+\url{https://github.com/rstudio/bookdown/blob/master/inst/templates/gitbook.html}.}
 
 \item{split_by}{How to name the HTML output files from the book: \code{rmd}
 uses the base filenames of the input Rmd files to create the HTML

--- a/man/gitbook.Rd
+++ b/man/gitbook.Rd
@@ -5,9 +5,9 @@
 \title{The GitBook output format}
 \usage{
 gitbook(fig_caption = TRUE, number_sections = TRUE, self_contained = FALSE, 
-    lib_dir = "libs", pandoc_args = NULL, ..., template = bookdown_file("templates", 
-        "gitbook.html"), split_by = c("chapter", "chapter+number", "section", 
-        "section+number", "rmd", "none"), split_bib = TRUE, config = list())
+    lib_dir = "libs", pandoc_args = NULL, ..., template = "default", 
+    split_by = c("chapter", "chapter+number", "section", "section+number", 
+        "rmd", "none"), split_bib = TRUE, config = list())
 }
 \arguments{
 \item{fig_caption, number_sections, self_contained, lib_dir, pandoc_args}{...
@@ -18,10 +18,7 @@ Arguments to be passed to \code{rmarkdown::\link{html_document}()}
 \code{html_book()} and \code{tufte_html_book()}, \code{...} is passed to
 \code{html_chapters()}.}
 
-\item{template}{See
-\code{rmarkdown::\link{html_document}},
-\code{tufte::\link[tufte]{tufte_html}}, or the documentation of the
-\code{base_format} function.}
+\item{template}{Pandoc template to use for rendering. Pass "default" to use the rmarkdown package default template; pass a path to use a custom template that you've created. The default template should be sufficient for most use cases. In case you want to develop a custom template, we highly recommend to start from the \href{https://github.com/rstudio/bookdown/blob/master/inst/templates/gitbook.html}{rmarkdown package default template}.}
 
 \item{split_by}{How to name the HTML output files from the book: \code{rmd}
 uses the base filenames of the input Rmd files to create the HTML

--- a/man/gitbook.Rd
+++ b/man/gitbook.Rd
@@ -5,17 +5,23 @@
 \title{The GitBook output format}
 \usage{
 gitbook(fig_caption = TRUE, number_sections = TRUE, self_contained = FALSE, 
-    lib_dir = "libs", pandoc_args = NULL, ..., split_by = c("chapter", "chapter+number", 
-        "section", "section+number", "rmd", "none"), split_bib = TRUE, config = list())
+    lib_dir = "libs", pandoc_args = NULL, ..., template = bookdown_file("templates", 
+        "gitbook.html"), split_by = c("chapter", "chapter+number", "section", 
+        "section+number", "rmd", "none"), split_bib = TRUE, config = list())
 }
 \arguments{
 \item{fig_caption, number_sections, self_contained, lib_dir, pandoc_args}{...
 Arguments to be passed to \code{rmarkdown::\link{html_document}()}
-(\code{...} not including \code{toc}, \code{theme}, and \code{template}).}
+(\code{...} not including \code{toc}, and \code{theme}).}
 
 \item{...}{Other arguments to be passed to \code{base_format}. For
 \code{html_book()} and \code{tufte_html_book()}, \code{...} is passed to
 \code{html_chapters()}.}
+
+\item{template}{See
+\code{rmarkdown::\link{html_document}},
+\code{tufte::\link[tufte]{tufte_html}}, or the documentation of the
+\code{base_format} function.}
 
 \item{split_by}{How to name the HTML output files from the book: \code{rmd}
 uses the base filenames of the input Rmd files to create the HTML


### PR DESCRIPTION
The output only changes when the user explicitly provides a `template`. The output isn't changed when no `template` is given, making the changes backward compatible.