### PR TITLE
Update preamble.tex

### DIFF
--- a/inst/examples/latex/preamble.tex
+++ b/inst/examples/latex/preamble.tex
@@ -50,7 +50,10 @@
  \at@end@of@kframe}
 \makeatother
 
-\renewenvironment{Shaded}{\begin{kframe}}{\end{kframe}}
+\makeatletter
+\@ifundefined{Shaded}{
+}{\renewenvironment{Shaded}{\begin{kframe}}{\end{kframe}}}
+\makeatother
 
 \newenvironment{rmdblock}[1]
   {


### PR DESCRIPTION
Shaded environment is not defined when R chunks are not used in document.
https://github.com/yihui/bookdown-chinese/commit/a3e392593b464ba31a7eceb0cd60f7e0bd112798

It's not really an issue, because your latex template was made for your book. I only had a problem when I tried to use your latex template without R chunks.