### PR TITLE
Add recursive = TRUE to unlink functions in render.R

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -154,7 +154,7 @@ render_new_session = function(files, main, config, output_format, clean, envir, 
 
   # save a copy of render arguments in a temp file
   render_args = tempfile('render', '.', '.rds')
-  on.exit(unlink(render_args), add = TRUE)
+  on.exit(unlink(render_args, recursive = TRUE), add = TRUE)
   saveRDS(
     list(output_format = output_format, ..., clean = FALSE, envir = envir),
     render_args
@@ -186,7 +186,7 @@ render_new_session = function(files, main, config, output_format, clean, envir, 
       write_utf8(txt, f)
       Rscript_render(f, render_args, render_meta)
     }, finally = {
-      if (file.copy(f2, f, overwrite = TRUE)) unlink(f2)
+      if (file.copy(f2, f, overwrite = TRUE)) unlink(f2, recursive = TRUE)
     })
   }
   if (!all(dirname(files_md) == '.'))

--- a/R/render.R
+++ b/R/render.R
@@ -64,7 +64,7 @@ render_book = function(
   if (clean_envir) rm(list = ls(envir, all.names = TRUE), envir = envir)
 
   if (config_file != '_bookdown.yml') {
-    unlink(tmp_config <- tempfile('_bookdown_', '.', '.yml'))
+    unlink(tmp_config <- tempfile('_bookdown_', '.', '.yml'), recursive = TRUE)
     if (file.exists('_bookdown.yml')) file.rename('_bookdown.yml', tmp_config)
     file.rename(config_file, '_bookdown.yml')
     on.exit({
@@ -131,7 +131,7 @@ render_book = function(
   } else {
     render_cur_session(files, main, config, output_format, clean, envir, ...)
   }
-  unlink(main)
+  unlink(main, recursive = TRUE)
   res
 }
 

--- a/R/render.R
+++ b/R/render.R
@@ -64,7 +64,7 @@ render_book = function(
   if (clean_envir) rm(list = ls(envir, all.names = TRUE), envir = envir)
 
   if (config_file != '_bookdown.yml') {
-    unlink(tmp_config <- tempfile('_bookdown_', '.', '.yml'), recursive = TRUE)
+    unlink(tmp_config <- tempfile('_bookdown_', '.', '.yml'))
     if (file.exists('_bookdown.yml')) file.rename('_bookdown.yml', tmp_config)
     file.rename(config_file, '_bookdown.yml')
     on.exit({
@@ -131,7 +131,7 @@ render_book = function(
   } else {
     render_cur_session(files, main, config, output_format, clean, envir, ...)
   }
-  unlink(main, recursive = TRUE)
+  file.remove(main)
   res
 }
 
@@ -154,7 +154,7 @@ render_new_session = function(files, main, config, output_format, clean, envir, 
 
   # save a copy of render arguments in a temp file
   render_args = tempfile('render', '.', '.rds')
-  on.exit(unlink(render_args, recursive = TRUE), add = TRUE)
+  on.exit(file.remove(render_args), add = TRUE)
   saveRDS(
     list(output_format = output_format, ..., clean = FALSE, envir = envir),
     render_args
@@ -186,7 +186,7 @@ render_new_session = function(files, main, config, output_format, clean, envir, 
       write_utf8(txt, f)
       Rscript_render(f, render_args, render_meta)
     }, finally = {
-      if (file.copy(f2, f, overwrite = TRUE)) unlink(f2, recursive = TRUE)
+      if (file.copy(f2, f, overwrite = TRUE)) file.remove(f2)
     })
   }
   if (!all(dirname(files_md) == '.'))


### PR DESCRIPTION
The creation of temp files using the `tempfile()` function creates files with a path of ".\\\filename".  However, when using the `unlink `function with default of `recursive = FALSE`, these created temp files are not removed as expected.  When `recursive = TRUE` is added to the unlink function call, then it works.  Code which reproduces the problem on my machine is below:

```r
## mimic creation of tempFile name as is done in bookdown::render.R
tempFile = tempfile('render', '.', '.rds')
print(tempFile)
file.exists(tempFile)  ### returns FALSE, nothing written to file

## write something to file
writeLines("This is a temp file", con = tempFile)
file.exists(tempFile)  ### returns TRUE

## use unlink with default value of recursive = FALSE
unlink(tempFile)

## check if file exists
file.exists(tempFile)  ### returns TRUE, file still exists!

## use unlink with non-default value of recursive = TRUE
unlink(tempFile, recursive = TRUE)

## check if file exists
file.exists(tempFile)  ### returns FALSE, finally got rid of it

## I do not know why this option needs to be TRUE as it does not
## seem we are doing a recursive search down a directory tree.
## My only guess is it has something to to with the path specification
## as tempFile = ".\\render2b885fcas674b.rds" and I am not familiar
## with the ".\\" notation.
```