### PR TITLE
Solve error without .Rprofile

### DIFF
--- a/inst/examples/index.Rmd
+++ b/inst/examples/index.Rmd
@@ -26,9 +26,10 @@ options(
   width = 55, digits = 4, warnPartialMatchAttr = FALSE, warnPartialMatchDollar = FALSE
 )
 
-local({r <- getOption("repos")
-  r["CRAN"] <- "https://cran.rstudio.com/" 
-  options(repos=r)
+local({
+  r = getOption('repos')
+  if (!length(r) || identical(r['CRAN'], '@CRAN@')) r['CRAN'] = 'https://cran.rstudio.com' 
+  options(repos = r)
 })
 
 lapply(c('DT', 'citr', 'formatR', 'svglite'), function(pkg) {

--- a/inst/examples/index.Rmd
+++ b/inst/examples/index.Rmd
@@ -26,7 +26,10 @@ options(
   width = 55, digits = 4, warnPartialMatchAttr = FALSE, warnPartialMatchDollar = FALSE
 )
 
-if (!length(getOption('repos'))) options(repos = c(CRAN = 'https://cran.rstudio.com'))
+local({r <- getOption("repos")
+  r["CRAN"] <- "https://cran.rstudio.com/" 
+  options(repos=r)
+})
 
 lapply(c('DT', 'citr', 'formatR', 'svglite'), function(pkg) {
   if (system.file(package = pkg) == '') install.packages(pkg)


### PR DESCRIPTION
Error in contrib.url(repos, type) :
trying to use CRAN without setting a mirror
Calls: ... lapply -> FUN -> install.packages -> grep -> contrib.url

if without .Rprofile, the original code can pop the same error.