### PR TITLE
pdf_book: combine references and out.height

### DIFF
--- a/R/latex.R
+++ b/R/latex.R
@@ -107,6 +107,8 @@ tufte_book2 = function(...) {
 
 resolve_refs_latex = function(x) {
   # equation references \eqref{}
+  x = gsub( '(?<=\\\\)@ref\\((eq:[-/:[:alnum:]]+)\\)', '\\eqref{\\1}',
+           x, perl = TRUE )
   x = gsub(
     '(?<!\\\\textbackslash{})@ref\\((eq:[-/:[:alnum:]]+)\\)', '\\\\eqref{\\1}', x,
     perl = TRUE

--- a/R/latex.R
+++ b/R/latex.R
@@ -106,16 +106,23 @@ tufte_book2 = function(...) {
 }
 
 resolve_refs_latex = function(x) {
-  # equation references \eqref{}
-  x = gsub( '(?<=\\\\)@ref\\((eq:[-/:[:alnum:]]+)\\)', '\\eqref{\\1}',
-           x, perl = TRUE )
+  ## In case the out.width or out.height options were specified, the
+  ## handling of the references requires are specialized handling. The
+  ## whole string specifying figure will be present in a single line
+  ## and the main gsub statement won't work
+  if ( length( grep( "\\\\includegraphics", x ) ) > 0 ){
+    x[ grep( "\\\\includegraphics", x ) ] <-
+      gsub( '(?<=\\\\)@ref\\((eq:[-/:[:alnum:]]+)\\)', '\\eqref{\\1}',
+           x[ grep( "\\\\includegraphics", x ) ], perl = TRUE )
+    x[ grep( "\\\\includegraphics", x ) ] <-
+      gsub( '(?<=\\\\)@ref\\(([-/:[:alnum:]]+)\\)', '\\ref{\\1}',
+           x[ grep( "\\\\includegraphics", x ) ], perl = TRUE )
+  }
   x = gsub(
     '(?<!\\\\textbackslash{})@ref\\((eq:[-/:[:alnum:]]+)\\)', '\\\\eqref{\\1}', x,
     perl = TRUE
   )
   # normal references \ref{}
-  x = gsub( '(?<=\\\\)@ref\\(([-/:[:alnum:]]+)\\)', '\\ref{\\1}',
-           x, perl = TRUE )
   x = gsub(
     '(?<!\\\\textbackslash{})@ref\\(([-/:[:alnum:]]+)\\)', '\\\\ref{\\1}', x,
     perl = TRUE

--- a/R/latex.R
+++ b/R/latex.R
@@ -112,6 +112,8 @@ resolve_refs_latex = function(x) {
     perl = TRUE
   )
   # normal references \ref{}
+  x = gsub( '(?<=\\\\)@ref\\(([-/:[:alnum:]]+)\\)', '\\ref{\\1}',
+           x, perl = TRUE )
   x = gsub(
     '(?<!\\\\textbackslash{})@ref\\(([-/:[:alnum:]]+)\\)', '\\\\ref{\\1}', x,
     perl = TRUE


### PR DESCRIPTION
When using the chunk option `out.height` the figure caption is translated differently.

Usually, all the content of the `includegraphics` command is separated into indiviual lines, like the path to the file, the label, the caption command, and the caption text itself. All occurrences of `\\ref()` have been replaced by `@ref()`.

But whenever the `out.height` option is present the whole `includegraphics` command will be returned in one line with the `\\@ref()` still intact. These will result to `\\ref{}` in the final document and cause LaTeX to throw an error.

This issue is resolved be adding an additional lines dealing with the `\\@ref()` instances arriving at the `pdf_book` function.

This fixes issue #606 .

P.S. I already signed a contribution agreement ones.
P.P.S The name of the branch I created the pull request from is kinda misleading. Well, it's already late but its all about the `pdf_book` function.