### PR TITLE
Change name of temporary files created.

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -178,7 +178,7 @@ render_new_session = function(files, main, config, output_format, clean, envir, 
       next
     }
     # first backup the original Rmd to a tempfile
-    f2 = tempfile('bookdown', '.')
+    f2 = paste0(f, '.bak')
     file.copy(f, f2, overwrite = TRUE)
     # write add1/add2 to the original Rmd, compile it, and restore it
     tryCatch({

--- a/R/render.R
+++ b/R/render.R
@@ -178,7 +178,7 @@ render_new_session = function(files, main, config, output_format, clean, envir, 
       next
     }
     # first backup the original Rmd to a tempfile
-    f2 = paste0(f, '.bak')
+    f2 = tempfile('bookdown', '.', fileext = '.bak')
     file.copy(f, f2, overwrite = TRUE)
     # write add1/add2 to the original Rmd, compile it, and restore it
     tryCatch({


### PR DESCRIPTION
Currently, during rending the code copies the backs up the R markdown file to a temporary file in the same directory with the a name like `bookdown11b6326822f9c`. This file should be cleaned up, but sometimes is not if the process is killed. If the file happens to not be cleaned up, it is hard to write a globbing expression for `.gitignore` and similar to match it that and wouldn't result in false positives; `bookdown*` is the best I can come up with. I propose

1. Use a `.bak` extension to make it easier to match with globbing.
2. Use the original filename as the base, since it is backing up a particular file. If the process is killed, then it is easier to restore the original file.

Alternatively, if the backup file never needs to be restored by the user, why not put it in the temporary directory?

Addresses #612