### PR TITLE
Update deprecated pandoc_args for pdfs in book

### DIFF
--- a/inst/examples/04-customization.Rmd
+++ b/inst/examples/04-customization.Rmd
@@ -133,13 +133,13 @@ output:
 
 Some publishers (e.g., Springer and Chapman & Hall/CRC) have their own LaTeX style or class files. You may try to change the `documentclass` option to use their document classes, although typically it is not as simple as that. You may end up using `in_header`, or even design a custom Pandoc LaTeX template to accommodate these document classes.
 
-Note that when you change `documentclass`, you are likely to specify an additional Pandoc argument `--chapters` so that Pandoc knows the first-level headers should be treated as chapters instead of sections (this is the default when `documentclass` is `book`), e.g.,
+Note that when you change `documentclass`, you are likely to specify an additional Pandoc argument `--top-level-division=chapter` so that Pandoc knows the first-level headers should be treated as chapters instead of sections (this is the default when `documentclass` is `book`), e.g.,
 
 ```yaml
 documentclass: krantz
 output:
   bookdown::pdf_book:
-    pandoc_args: --chapters
+    pandoc_args: --top-level-division=chapter
 ```
 
 ## Templates

--- a/inst/examples/06-publishing.Rmd
+++ b/inst/examples/06-publishing.Rmd
@@ -198,7 +198,7 @@ bookdown::pdf_book:
   latex_engine: xelatex
   citation_package: natbib
   template: null
-  pandoc_args: "--chapters"
+  pandoc_args: --top-level-division=chapter
   toc_unnumbered: no
   toc_appendix: yes
   quote_footer: ["\\VA{", "}{}"]


### PR DESCRIPTION
The pandoc argument `--chapters` was deprecated in favor of `--top-level-division=chapter`, and this change [was made](https://github.com/rstudio/bookdown/commit/90f4c8d65d7d612b9ed280fd05ec3a1bb65d25d8) for `_output.yml` but not for the content in the book. 

This PR updates the book's text to the modern pandoc argument.
For Ch.6, I chose not to enclose the argument with quotes to make it consistent with Ch.4, and also because that's how `_output.yml` does it. 