### PR TITLE
Make the strong tag more differentiable

### DIFF
--- a/inst/examples/css/style.css
+++ b/inst/examples/css/style.css
@@ -62,5 +62,5 @@ h1.title {
   font-variant: small-caps;
 }
 .book .book-body .page-wrapper .page-inner section.normal strong {
-  font-weight: 500;
+  font-weight: 600;
 }


### PR DESCRIPTION
I would use 600 instead of 500 because I can't see the difference between 500 and 400 using my notebook and others may have the same problem.

![screenshot](https://user-images.githubusercontent.com/42358990/45266527-8060eb80-b432-11e8-9966-b5dcbf01c640.png)

@yihui do you agree?