### PR TITLE
Fix using utils::URLdecode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@
 
 - Previously the `rmd_files` parameter in `_bookdown.yml` would override `rmd_subdir`, but now both parameters can be used simultaneously (thanks, @ellisvalentiner, #600).
 
-- Resources with URL encoded special characters are now correctly copied to the output directory (thanks, @AshesITR, #622)
+- Resources with URL encoded special characters are now correctly copied to the output directory (thanks, @AshesITR, #622).
 
 # CHANGES IN bookdown VERSION 0.7
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 - Previously the `rmd_files` parameter in `_bookdown.yml` would override `rmd_subdir`, but now both parameters can be used simultaneously (thanks, @ellisvalentiner, #600).
 
+- Resources with URL encoded special characters are now correctly copied to the output directory (thanks, @AshesITR, #622)
+
 # CHANGES IN bookdown VERSION 0.7
 
 ## MAJOR CHANGES

--- a/R/html.R
+++ b/R/html.R
@@ -897,6 +897,7 @@ move_files_html = function(output, lib_dir) {
     if (length(z) == 0) z else gsub(r, '\\2', z)
   }))
   f = c(f, parse_cover_image(x))
+  f = vapply(f, utils::URLdecode, FUN.VALUE = character(1))
   f = local_resources(unique(f[file.exists(f)]))
   # detect resources in CSS
   css = lapply(grep('[.]css$', f, ignore.case = TRUE, value = TRUE), function(z) {


### PR DESCRIPTION
I've personally tested this only on a minimal example:

 1. Create a new RStudio project using the bookdown template
 2. Add this code chunk somewhere (e.g. bottom of index.Rmd):
   
```{r this will not show}
library(ggplot2)

ggplot(iris, aes(x = Petal.Length, y = Petal.Width, color = Species)) + geom_point()
```

 3. Verify bug: The image doesn't show because the resource is missing (png is named "this will not show-1.png" while the src attribute is URLencoded to "this%20will%20..."
 4. Install this branch and rerun
 5. The image is now correctly copied and displays (in Firefox, oddly *not* in the RStudio preview browser, but that is another bug found I guess...)