### PR TITLE
Fix serve_book when not running in RStudio

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 - Resources with URL encoded special characters are now correctly copied to the output directory (thanks, @AshesITR, #622).
 
+- `serve_book()` can now be used without error when rstudioapi is installed but RStudio is not being used (thanks, @jimhester, #637).
+
 # CHANGES IN bookdown VERSION 0.7
 
 ## MAJOR CHANGES

--- a/R/utils.R
+++ b/R/utils.R
@@ -268,7 +268,8 @@ serve_book = function(
 ) {
   # when this function is called via the RStudio addin, use the dir of the
   # current active document
-  if (missing(dir) && requireNamespace('rstudioapi', quietly = TRUE)) {
+  if (missing(dir) && requireNamespace('rstudioapi', quietly = TRUE) &&
+      rstudioapi::isAvailable()) {
     path = rstudioapi::getSourceEditorContext()[['path']]
     if (!(is.null(path) || path == '')) dir = dirname(path)
   }


### PR DESCRIPTION
If the rstudioapi package is installed but serve_book is called outside
of RStudio `getSourceEditorContext()` would signal an error.

We now check if RStudio is available first, which fixes the issue.