### PR TITLE
Added label to search form for screen readers

### DIFF
--- a/inst/resources/gitbook/js/plugin-search.js
+++ b/inst/resources/gitbook/js/plugin-search.js
@@ -1,6 +1,6 @@
 gitbook.require(["gitbook", "lodash", "jQuery"], function(gitbook, _, $) {
     var index = null;
-    var $searchInput, $searchForm;
+    var $searchInput, $searchLabel, $searchForm;
     var $highlighted, hi = 0, hiOpts = { className: 'search-highlight' };
     var collapse = false;
 
@@ -92,20 +92,30 @@ gitbook.require(["gitbook", "lodash", "jQuery"], function(gitbook, _, $) {
     // Create search form
     function createForm(value) {
         if ($searchForm) $searchForm.remove();
+        if ($searchLabel) $searchLabel.remove();
         if ($searchInput) $searchInput.remove();
 
         $searchForm = $('<div>', {
             'class': 'book-search',
             'role': 'search'
         });
+        
+        $searchLabel = $('<label>', {
+            'for': 'search-box',
+            'aria-hidden': 'false',
+            'hidden': ''
+        });
 
         $searchInput = $('<input>', {
+            'id': 'search-box',
             'type': 'search',
             'class': 'form-control',
             'val': value,
             'placeholder': 'Type to search'
         });
-
+        
+        $searchLabel.append("Type to search");
+        $searchLabel.appendTo($searchForm);
         $searchInput.appendTo($searchForm);
         $searchForm.prependTo(gitbook.state.$book.find('.book-summary'));
     }

--- a/inst/resources/gitbook/js/plugin-search.js
+++ b/inst/resources/gitbook/js/plugin-search.js
@@ -99,7 +99,7 @@ gitbook.require(["gitbook", "lodash", "jQuery"], function(gitbook, _, $) {
             'class': 'book-search',
             'role': 'search'
         });
-        
+
         $searchLabel = $('<label>', {
             'for': 'search-box',
             'aria-hidden': 'false',
@@ -113,7 +113,7 @@ gitbook.require(["gitbook", "lodash", "jQuery"], function(gitbook, _, $) {
             'val': value,
             'placeholder': 'Type to search'
         });
-        
+
         $searchLabel.append("Type to search");
         $searchLabel.appendTo($searchForm);
         $searchInput.appendTo($searchForm);


### PR DESCRIPTION
Appended HTML <label> to $searchForm for increased accessibility. The label will help screen readers that may not read the <input> placeholder attribute (in this case, "Type to search"). The procedure to add a <label> element alongside an <input> is suggested by Khan Academy's [tota11y accessibility tool](https://github.com/Khan/tota11y). Refer to [W3C on labels and web accessibility](https://www.w3.org/WAI/tutorials/forms/labels/).