### PR TITLE
Add support for Hungarian language @aref

### DIFF
--- a/R/ebook.R
+++ b/R/ebook.R
@@ -126,8 +126,8 @@ resolve_refs_md = function(content, ref_table, to_md = output_md()) {
   # replace (\#eq:label) with equation numbers
   content = add_eq_numbers(content, ids, ref_table, to_md)
 
-  # look for \@ref(label) and resolve to actual figure/table/section numbers
-  m = gregexpr('(?<!`)\\\\@ref\\(([-:[:alnum:]]+)\\)', content, perl = TRUE)
+  # look for \@ref(label) or \@aref(label) and resolve to actual figure/table/section numbers
+  m = gregexpr('(?<!`)\\\\@a?ref\\(([-:[:alnum:]]+)\\)', content, perl = TRUE)
   refs = regmatches(content, m)
   regmatches(content, m) = lapply(refs, ref_to_number, ref_table, TRUE)
   content

--- a/R/html.R
+++ b/R/html.R
@@ -453,7 +453,8 @@ source_link_setting = function(config, type) {
 #'
 #' Post-process the HTML content to resolve references of figures, tables, and
 #' sections, etc. The references are written in the form \code{\@ref(key)} in
-#' the R Markdown source document.
+#' or \code{\@aref(key)} the R Markdown source document, the latter intended
+#' for use with Hungarian language text.
 #' @param content A character vector of the HTML content.
 #' @param global Whether to number the elements incrementally throughout the
 #'   whole document, or number them by the first-level headers. For an R
@@ -488,15 +489,16 @@ resolve_refs_html = function(content, global = FALSE) {
   content
 }
 
-magyar_article = function(num) {
-  ifelse(grepl("^5", num) |
-        (grepl("^1", num) & (nchar(num) %% 3 == 1)), "ar", "a")
-}
-
 is_img_line = function(x) grepl('^<img src=".* alt="', x)
 
 ref_to_number = function(ref, ref_table, backslash) {
   if (length(ref) == 0) return(ref)
+  magyar_article = function(num) {
+    num <- sub("[.].*$", "", num)
+    num <- sub("[^[:digit:]]", "", num)
+    ifelse(grepl("^5", num) |
+             (grepl("^1", num) & (nchar(num) %% 3 == 1)), "az", "a")
+  }
   aref = grepl("@aref", ref)
   lab = gsub(if (backslash) '^\\\\@a?ref\\(|\\)$' else '^@a?ref\\(|\\)$', '', ref)
   ref = prefix_section_labels(lab)
@@ -507,12 +509,12 @@ ref_to_number = function(ref, ref_table, backslash) {
       warning('The label(s) ', paste(lab[i], collapse = ', '), ' not found', call. = FALSE)
     num[i] = '<strong>??</strong>'
   }
-  ar <- magyar_article(num[aref])
+  az <- magyar_article(num[aref])
   # equation references should include parentheses
   i = grepl('^eq:', ref)
   num[i] = paste0('(', num[i], ')')
-  num[aref] <- paste(ar, num[aref])
   res = sprintf('<a href="#%s">%s</a>', ref, num)
+  res[aref] <- paste(az, res[aref])
   # do not add relative links to equation numbers in ePub/Word (not implemented)
   ifelse(backslash & i, num, res)
 }

--- a/R/html.R
+++ b/R/html.R
@@ -472,8 +472,8 @@ resolve_refs_html = function(content, global = FALSE) {
   content = res$content
   ref_table = c(res$ref_table, parse_section_labels(content))
 
-  # look for @ref(label) and resolve to actual figure/table/section numbers
-  m = gregexpr('(?<!\\\\)@ref\\(([-:[:alnum:]]+)\\)', content, perl = TRUE)
+  # look for @ref(label) or @aref(label) and resolve to actual figure/table/section numbers
+  m = gregexpr('(?<!\\\\)(@a?ref)\\(([-:[:alnum:]]+)\\)', content, perl = TRUE)
   refs = regmatches(content, m)
   for (i in seq_along(refs)) {
     if (length(refs[[i]]) == 0) next
@@ -488,11 +488,17 @@ resolve_refs_html = function(content, global = FALSE) {
   content
 }
 
+magyar_article = function(num) {
+  ifelse(grepl("^5", num) |
+        (grepl("^1", num) & (nchar(num) %% 3 == 1)), "ar", "a")
+}
+
 is_img_line = function(x) grepl('^<img src=".* alt="', x)
 
 ref_to_number = function(ref, ref_table, backslash) {
   if (length(ref) == 0) return(ref)
-  lab = gsub(if (backslash) '^\\\\@ref\\(|\\)$' else '^@ref\\(|\\)$', '', ref)
+  aref = grepl("@aref", ref)
+  lab = gsub(if (backslash) '^\\\\@a?ref\\(|\\)$' else '^@a?ref\\(|\\)$', '', ref)
   ref = prefix_section_labels(lab)
   num = ref_table[ref]
   i = is.na(num)
@@ -501,9 +507,11 @@ ref_to_number = function(ref, ref_table, backslash) {
       warning('The label(s) ', paste(lab[i], collapse = ', '), ' not found', call. = FALSE)
     num[i] = '<strong>??</strong>'
   }
-  # equation references should include paratheses
+  ar <- magyar_article(num[aref])
+  # equation references should include parentheses
   i = grepl('^eq:', ref)
   num[i] = paste0('(', num[i], ')')
+  num[aref] <- paste(ar, num[aref])
   res = sprintf('<a href="#%s">%s</a>', ref, num)
   # do not add relative links to equation numbers in ePub/Word (not implemented)
   ifelse(backslash & i, num, res)

--- a/R/latex.R
+++ b/R/latex.R
@@ -109,12 +109,12 @@ tufte_book2 = function(...) {
 resolve_refs_latex = function(x) {
   # equation references \eqref{}
   x = gsub(
-    '(?<!\\\\textbackslash{})@ref\\((eq:[-/:[:alnum:]]+)\\)', '\\\\eqref{\\1}', x,
+    '(?<!\\\\textbackslash{})@a?ref\\((eq:[-/:[:alnum:]]+)\\)', '\\\\eqref{\\1}', x,
     perl = TRUE
   )
-  # normal references \ref{}
+  # normal references \ref{} or \aref{}
   x = gsub(
-    '(?<!\\\\textbackslash{})@ref\\(([-/:[:alnum:]]+)\\)', '\\\\ref{\\1}', x,
+    '(?<!\\\\textbackslash{})@(a?)ref\\(([-/:[:alnum:]]+)\\)', '\\\\\\1ref{\\2}', x,
     perl = TRUE
   )
   x = gsub(sprintf('\\(\\\\#((%s):[-/[:alnum:]]+)\\)', reg_label_types), '\\\\label{\\1}', x)


### PR DESCRIPTION
As mentioned in Issue #671, the babel Hungarian support in LaTeX adds the macro `\aref` to be like `\ref` but with support for some special Hungarian grammatical constraints.

This PR takes the changes from my [magyarbookdown](https://github.com/dmurdoch/magyarbookdown) package and includes them in `bookdown`.   I'm not sure this is an appropriate addition, but I'll let you decide.