### PR TITLE
Retain sorting in split reference sections of gitbook as defined in CSL file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,7 @@ Authors@R: c(
     person("Albert", "Kim", role = "ctb"),
     person("Alessandro", "Samuel-Rosa", role = "ctb"),
     person("Andrzej", "Oles", role = "ctb"),
+    person("Aust", "Frederik", role = "ctb", comment = c(ORCID = "0000-0003-4900-788X")),
     person("Bastiaan", "Quast", role = "ctb"),
     person("Ben", "Marwick", role = "ctb"),
     person("Chester", "Ismay", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # CHANGES IN bookdown VERSION 0.10
 
+## BUG FIXES
 
+- Split reference sections in `gitbook` ignored the sorting definition of the citation style (thanks @GegznaV #661, @crsh #672).
 
 # CHANGES IN bookdown VERSION 0.9
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## BUG FIXES
 
-- Split reference sections in `gitbook` ignored the sorting definition of the citation style (thanks @GegznaV #661, @crsh #672).
+- Split reference sections in `gitbook` ignored the sorting definition of the citation style (thanks @GegznaV #661, @crsh #674).
 
 # CHANGES IN bookdown VERSION 0.9
 

--- a/R/html.R
+++ b/R/html.R
@@ -843,7 +843,7 @@ parse_references = function(x) {
 # move references back to the relevant chapter
 relocate_references = function(x, refs, title, ids) {
   if (length(refs) == 0) return(x)
-  ids = intersect(ids, names(refs))
+  ids = intersect(names(refs), ids)
   if (length(ids) == 0) return(x)
   title = if (is.null(title)) '<h3>References</h3>' else gsub('h1>', 'h3>', title)
   c(x, title, '<div id="refs" class="references">', refs[ids], '</div>')


### PR DESCRIPTION
As reported in #661, the split reference sections in `gitbook` do not respect the sorting defined in the CSL file. Instead references are always listed in the order of citations in the text of the current page. This PR ensures that the sorting in the split reference sections adheres to the CSL definition. Currently, this is hard coded. If you prefer I'd be happy to add an argument, e.g., `split_bib_sorting`, that allows selecting any of these two behaviors.