### PR TITLE
feat: toggle clean_pandoc2_highlight_tags in html_document2

### DIFF
--- a/R/html.R
+++ b/R/html.R
@@ -110,6 +110,8 @@ tufte_html_book = function(...) {
 #'   (the i-th figure/table); if \code{FALSE}, figures/tables will be numbered
 #'   sequentially in the document from 1, 2, ..., and you cannot cross-reference
 #'   section headers in this case.
+#' @param highlight_cleaned Whether to remove the <div> tags around <pre>,
+#'   and clean up <a> on all lines in code blocks (default: `TRUE`).
 #' @inheritParams pdf_book
 #' @return An R Markdown output format object to be passed to
 #'   \code{rmarkdown::\link{render}()}.
@@ -121,7 +123,8 @@ tufte_html_book = function(...) {
 #' @references \url{https://bookdown.org/yihui/bookdown/}
 #' @export
 html_document2 = function(
-  ..., number_sections = TRUE, pandoc_args = NULL, base_format = rmarkdown::html_document
+  ..., number_sections = TRUE, pandoc_args = NULL, base_format = rmarkdown::html_document,
+  highlight_cleaned = TRUE
 ) {
   base_format = get_base_format(base_format)
   config = base_format(
@@ -134,7 +137,7 @@ html_document2 = function(
     x = restore_appendix_html(x, remove = FALSE)
     x = restore_part_html(x, remove = FALSE)
     x = resolve_refs_html(x, global = !number_sections)
-    x = clean_pandoc2_highlight_tags(x)
+    if (highlight_cleaned) x = clean_pandoc2_highlight_tags(x)
     write_utf8(x, output)
     output
   }

--- a/man/html_document2.Rd
+++ b/man/html_document2.Rd
@@ -11,7 +11,7 @@
 figures/tables/equations}
 \usage{
 html_document2(..., number_sections = TRUE, pandoc_args = NULL, 
-    base_format = rmarkdown::html_document)
+    base_format = rmarkdown::html_document, highlight_cleaned = TRUE)
 
 tufte_html2(..., number_sections = FALSE)
 
@@ -38,6 +38,9 @@ sequentially in the document from 1, 2, ..., and you cannot cross-reference
 section headers in this case.}
 
 \item{base_format}{An output format function to be used as the base format.}
+
+\item{highlight_cleaned}{Whether to remove the <div> tags around <pre>,
+and clean up <a> on all lines in code blocks (default: `TRUE`).}
 }
 \value{
 An R Markdown output format object to be passed to


### PR DESCRIPTION
I implemented a toggling option to the `clean_pandoc2_highlight_tags` in `html_document2` (Issue https://github.com/rstudio/bookdown/issues/705)

The toggling is achieved by specifying `highlight_cleaned` in a YAML front matter, which is `TRUE` in default for consistency with previous versions.

If there is any better name for this option, please tell me.

Here's a reproducible example.

 ````
---
output:
  bookdown::html_document2:
    highlight: pygments
    highlight_cleaned: false
---
 
```{r, class.source = "numberLines lineAnchors", eval = FALSE}
head(iris)
```
````