### PR TITLE
allow user to custom abstract title when output is bookdown::gitbook

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Added an argument `clean_highlight_tags` to `html_document2()` (thanks, @atusy, #706).
 
+- For HTML output formats such as `gitbook`, the abstract title (if the abstract is provided) can be customized via the field `abstract-title` in the YAML frontmatter (thanks, @XiangyunHuang, #715).
+
 ## BUG FIXES
 
 - Split reference sections in `gitbook` ignored the sorting definition of the citation style (thanks @GegznaV #661, @crsh #674).

--- a/inst/templates/default.html
+++ b/inst/templates/default.html
@@ -147,7 +147,7 @@ $endif$
 </div>
 $if(abstract)$
 <div class="abstract">
-<p class="abstract">Abstract</p>
+<p class="abstract">$if(abstract-title)$$abstract-title$$else$Abstract$endif$</p>
 $abstract$
 </div>
 $endif$

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -112,7 +112,7 @@ $if(date)$
 $endif$
 $if(abstract)$
 <div class="abstract">
-<p class="abstract">Abstract</p>
+<p class="abstract">$if(abstract-title)$$abstract-title$$else$Abstract$endif$</p>
 $abstract$
 </div>
 $endif$


### PR DESCRIPTION
add Pandoc's variable $abstract-title$, so allow user to custom abstract title when output is bookdown::gitbook

see https://d.cosx.org/d/420658 for feature discuss 

