### PR TITLE
update: styles for code blocks

### DIFF
--- a/R/html.R
+++ b/R/html.R
@@ -1014,6 +1014,16 @@ clean_pandoc2_highlight_tags = function(x) {
   x = gsub('(</code></pre>)</div>', '\\1', x)
   x = gsub('<div class="sourceCode"[^>]+>(<pre)', '\\1', x)
   x = gsub('<a class="sourceLine"[^>]+>(.*)</a>', '\\1', x)
+
+  css_start = which(x == '<style type="text/css" data-origin="pandoc">')
+  style_end = which(x == '</style>')
+  css_end = vapply(css_start, function(x) style_end[x < style_end][1L], 1L)
+  css_range = intersect(
+    unlist(Map(seq, css_start, css_end)),
+    which(x %in% c("div.sourceCode { margin: 1em 0; }", "pre.sourceCode { margin: 0; }"))
+  )
+  if (length(css_range) > 0) x = x[-css_range]
+
   x
 }
 

--- a/inst/templates/default.html
+++ b/inst/templates/default.html
@@ -98,6 +98,23 @@ $if(theme)$
   margin-left: auto;
   margin-right: auto;
 }
+pre:not([class]),
+  pre[class="sourceCode numberSource numberLines"],
+  pre[class="sourceCode numberSource numberLines lineAnchors"],
+  pre[class="sourceCode numberSource numberLines line-anchors"],
+  pre[class="sourceCode numberSource number-lines"],
+  pre[class="sourceCode numberSource number-lines lineAnchors"],
+  pre[class="sourceCode numberSource number-lines line-anchors"],
+  pre[class="sourceCode numberSource lineAnchors numberLines"],
+  pre[class="sourceCode numberSource lineAnchors number-Lines"],
+  pre[class="sourceCode numberSource line-anchors numberLines"],
+  pre[class="sourceCode numberSource line-anchors number-lines"] {
+    background-color: white;
+}
+pre.sourceCode {
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
 code {
   color: inherit;
   background-color: rgba(0, 0, 0, 0.04);

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -77,6 +77,12 @@ $highlighting-css$
 </style>
 $endif$
 
+<style type="text/css">
+.numberLines code.sourceCode {
+  left: 1.5em;
+}
+</style>
+
 $for(css)$
 <link rel="stylesheet" href="$css$" $if(html5)$$else$type="text/css" $endif$/>
 $endfor$


### PR DESCRIPTION
This PR improves styles for code blocks. 

## html_document2 / html_chapter / html_book

This part is related to #733 and #706.

When Pandoc's syntax highlighting is enabled and `clean_highlight_tags: TRUE`, Pandoc embeds CSS and cause code blocks to have no margins. Exceptionally, the matter does not happen when `highlight: default` in `html_document2`

```css
div.sourceCode { margin: 1em 0; }
pre.sourceCode { margin: 0; }
```

For the `html_document2`, Pandoc embeds CSS starting from `<style type="text/css" data-origin="pandoc">`.
Thus, I decided to remove unwanted styles by updating `clean_pandoc2_tags`.

For the others, Pandoc embeds CSS starting from `<style type="text/css">`, which cannot be telled if the CSS is added by Pandoc or the user.
Thus, I decided to add CSS to template (`default.html`) to override the one embedded by Pandoc.
I also updated CSS in the similar way as https://github.com/rstudio/rmarkdown/pull/1596, so that output code blocks have white background when line numbering is enabled.

### Before

![image](https://user-images.githubusercontent.com/30277794/60689299-dbe6f300-9ef6-11e9-8e54-6866aac73ee7.png)

### After

![image](https://user-images.githubusercontent.com/30277794/60689259-5fecab00-9ef6-11e9-862f-93317c3993ce.png)


## html_gitbook

When line nubering is enabled for code blocks, they are positioned too left, and may overflow.
Thus I updated `html_gitbook`'s template.

### Before

![image](https://user-images.githubusercontent.com/30277794/60689285-bce86100-9ef6-11e9-8142-4a2a28138d6d.png)

### After

![image](https://user-images.githubusercontent.com/30277794/60689271-9cb8a200-9ef6-11e9-998d-86a574612883.png)


## Source code for examples above

The above output is rendered from the source code below with

- latest knitr on GitHub
- https://github.com/rstudio/rmarkdown/pull/1596

````
---
output: 
  bookdown::html_book: 
    highlight: default
  bookdown::html_document2:
    highlight: tango
  bookdown::gitbook: 
    highlight: tango
---

Numbered

```{r hello, class.source = "numberLines", class.output="numberLines", attr.output='startFrom="10"'}
"Hello World"
```

Unnumbered

```{r hello2}
"Hello World"
```
````
