### PR TITLE
Small adaptation for counting figures

### DIFF
--- a/R/html.R
+++ b/R/html.R
@@ -563,7 +563,7 @@ parse_fig_labels = function(content, global = FALSE) {
   m = gregexpr(sprintf('\\(#((%s):[-/[:alnum:]]+)\\)', reg_label_types), content)
   labs = regmatches(content, m)
   cntr = new_counters(label_types, chaps)  # chapter counters
-  figs = grep('^<div class="figure', content)
+  figs = grep('^<div( id=".*") class="figure', content)
   eqns = grep('<span class="math display">', content)
 
   for (i in seq_along(labs)) {

--- a/R/html.R
+++ b/R/html.R
@@ -563,7 +563,7 @@ parse_fig_labels = function(content, global = FALSE) {
   m = gregexpr(sprintf('\\(#((%s):[-/[:alnum:]]+)\\)', reg_label_types), content)
   labs = regmatches(content, m)
   cntr = new_counters(label_types, chaps)  # chapter counters
-  figs = grep('^<div( id=".*") class="figure', content)
+  figs = grep('^<div .*class="figure', content)
   eqns = grep('<span class="math display">', content)
 
   for (i in seq_along(labs)) {


### PR DESCRIPTION
The PR for `knitr` at https://github.com/yihui/knitr/pull/1752, which fixed the figure referencing issue in https://github.com/rstudio/bookdown/issues/766 and is discussed in https://github.com/rstudio/bookdown-demo/issues/42, causes an unintended side effect of putting `id` in front of class.  As referenced in https://github.com/yihui/knitr/pull/1752, 
https://github.com/rstudio/bookdown/blob/master/R/html.R#L566 needs to be edited so that it can go `<div id="asdf" class="figure`, which this PR addresses.