### PR TITLE
render_book supports self contained false for html_document2 and its extensions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 - Added copy to clipboard buttons to code blocks in the `gitbook` output format (thanks, @behrman #775, @RLesur #776).
 
+- `render_book` supports `self_contained: false` for `html_document2` and its extensions such as `pagedown::html_paged` (thanks, @atusy, #777)
+
 ## BUG FIXES
 
 - Images specified in `toc: before:` of the `gitbook` format are not copied to the output directory (thanks, @dcossyleon, #763).

--- a/R/html.R
+++ b/R/html.R
@@ -141,6 +141,7 @@ html_document2 = function(
     output
   }
   config$bookdown_output_format = 'html'
+  config$bookdown_move_files = FALSE
   config = set_opts_knit(config)
   config
 }

--- a/R/render.R
+++ b/R/render.R
@@ -82,21 +82,23 @@ render_book = function(
     output_dir = output_dir, input_rmd = basename(input), preview = preview
   )
 
-  aux_diro = '_bookdown_files'
-  # for compatibility with bookdown <= 0.0.64
-  if (isTRUE(dir_exists(aux_dir2 <- file.path(output_dir, aux_diro)))) {
-    if (!dir_exists(aux_diro)) file.rename(aux_dir2, aux_diro)
-  }
-  # move _files and _cache from _bookdown_files to ./, then from ./ to _bookdown_files
-  aux_dirs = files_cache_dirs(aux_diro)
-  move_dirs(aux_dirs, basename(aux_dirs))
-  on.exit({
-    aux_dirs = files_cache_dirs('.')
-    if (length(aux_dirs)) {
-      dir_create(aux_diro)
-      move_dirs(aux_dirs, file.path(aux_diro, basename(aux_dirs)))
+  if (bookdown_move_files(output_format)) {
+    aux_diro = '_bookdown_files'
+    # for compatibility with bookdown <= 0.0.64
+    if (isTRUE(dir_exists(aux_dir2 <- file.path(output_dir, aux_diro)))) {
+      if (!dir_exists(aux_diro)) file.rename(aux_dir2, aux_diro)
     }
-  }, add = TRUE)
+    # move _files and _cache from _bookdown_files to ./, then from ./ to _bookdown_files
+    aux_dirs = files_cache_dirs(aux_diro)
+    move_dirs(aux_dirs, basename(aux_dirs))
+    on.exit({
+      aux_dirs = files_cache_dirs('.')
+      if (length(aux_dirs)) {
+        dir_create(aux_diro)
+        move_dirs(aux_dirs, file.path(aux_diro, basename(aux_dirs)))
+      }
+    }, add = TRUE)
+  }
 
   # you may set, e.g., new_session: yes in _bookdown.yml
   if (is.na(new_session)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -365,6 +365,11 @@ target_format = function(format) {
   switch(format, tufte_book2 = 'latex', tufte_handout2 = 'latex')
 }
 
+bookdown_move_files = function(format) {
+  if (is.character(format)) format <- eval(parse(text = format))()
+  format$bookdown_move_files %n% TRUE
+}
+
 verify_rstudio_version = function() {
   if (requireNamespace('rstudioapi', quietly = TRUE) && rstudioapi::isAvailable()) {
     if (!rstudioapi::isAvailable('0.99.1200')) warning(


### PR DESCRIPTION
Currently, `render_book` moves all the dependencies to the `_bookdown_files` directory when rendering `html_document2` or its extensions.
However, the output HTML file is left in the working directory.
This is causing the output from `html_document2` and its extensions unable to find the dependencies.

This PR fixes this problem by suppress moving dependencies to the `_bookdown_files` directory.
Another possible approach is to move result HTML file and dependencies to `_book` directory, and rename the result HTML file to `index.html`.
I chose the former solution for backward compatibility as current `html_document2` generates an HTML file in the working directory.

In order to compare the results from current version and this PR,

1. Create Book Project using bookdown
2. Add following lines to `_output.yml`
  ```
  bookdown::html_document2:
    self_contained: false
  pagedown::html_paged:
    self_contained: false
  ```
3. Build book with `bookdown::html_document2` or `pagedown::html_paged`