### PR TITLE
Add compatibility with new pandoc2 way of creating self contained document

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # CHANGES IN bookdown VERSION 0.15
 
+## BUG FIXES
+
+- gitbook toolbar is not missing anymore when rendering bookdown books with pandoc2 and using `self_contained = TRUE`. (thanks, @Pindar777, @RLesur, @cderv, #739)
+
 
 # CHANGES IN bookdown VERSION 0.14
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,7 @@
 
 ## BUG FIXES
 
-- gitbook toolbar is not missing anymore when rendering bookdown books with pandoc2 and using `self_contained = TRUE`. (thanks, @Pindar777, @RLesur, @cderv, #739)
-
+- gitbook toolbar is not missing any more when rendering books with Pandoc 2.x and using `self_contained = TRUE` (thanks, @Pindar777, @RLesur, @cderv, #739).
 
 # CHANGES IN bookdown VERSION 0.14
 

--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -135,14 +135,11 @@ gitbook_page = function(
   # node must be found and moved.
   if (length(i) == 0) {
     s_start = grep(
-      '^\\s*<script( src="data:application/(x-)?javascript;base64,[^"]+")?>',
-      head)
+      '^\\s*<script( src="data:application/(x-)?javascript;base64,[^"]+")?>', head
+    )
     s_end = grep("</script>\\s*$", head)
     # find all lines to move
-    i = unlist(mapply(seq.int,
-                      from = s_start, to = s_end,
-                      MoreArgs = list(by = 1)
-    ))
+    i = unlist(mapply(seq.int, s_start, s_end, SIMPLIFY = FALSE))
   }
   s = head[i]; head[i] = ''
   j = grep('<!--bookdown:config-->', foot)[1]

--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -130,10 +130,20 @@ gitbook_page = function(
   # gitbook JS scripts only work after the DOM has been loaded, so move them
   # from head to foot
   i = grep('^\\s*<script src=".+/gitbook([^/]+)?/js/[.a-z-]+[.]js"></script>\\s*$', head)
-  # it is probably a self-contained page, so look for base64 encoded scripts
-  if (length(i) == 0) i = grep(
-    '^\\s*<script src="data:application/x-javascript;base64,[^"]+"></script>\\s*$', head
-  )
+  # it is probably a self-contained page, so look for script node.
+  # from pandoc2, they are not always base64 encoded scripts, so start and end of scripts
+  # node must be found and moved.
+  if (length(i) == 0) {
+    s_start = grep(
+      '^\\s*<script( src="data:application/(x-)?javascript;base64,[^"]+")?>',
+      head)
+    s_end = grep("</script>\\s*$", head)
+    # find all lines to move
+    i = unlist(mapply(seq.int,
+                      from = s_start, to = s_end,
+                      MoreArgs = list(by = 1)
+    ))
+  }
   s = head[i]; head[i] = ''
   j = grep('<!--bookdown:config-->', foot)[1]
   foot[j] = paste(c(s, foot[j]), collapse = '\n')


### PR DESCRIPTION
This will fix #739 using by using the same regex mechanism as of now. (See discussion in the issue)
See PR is a joint effort with @RLesur, Thanks Romain ! 

As explained in the discussion, Pandoc 2 changed the way it creates self contained document. JS script are now included inside `<script>` html tags no more base64 encoded by default. 
See https://github.com/rstudio/bookdown/issues/739#issuecomment-541349632
This means that bookdown must look for encoded and not encoded script html node. Also, it must look for possible multiline blocks and not single line html node.

This PR makes bookdown post processing compatible with all pandoc version by : 

* Modifying the regex to look for encoded and not encoded JS script
* deal with multiline blocks beginning with `<script>` and finishing with `</script>` to move all the lines

This PR has been tested locally using bookdown demo but also using the awesome pipeline from @RLesur to see if it works with all pandoc version (< 2 and > 2). 
See results in https://rlesur.gitlab.io/bookdown-issue739/ and pipeline in https://gitlab.com/RLesur/bookdown-issue739

One other solution for all this is to use JS directly so that the gitbook JS scripts are executed after the page loaded, as Romain suggested, and not regex to find, move and rewrite the html script. If this seems clever for the long run, this is an other PR we can open.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rstudio/bookdown/784)
<!-- Reviewable:end -->
