### PR TITLE
handle change in footnotes from pandoc 2.7.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## BUG FIXES
 
+- When using pandoc 2.7.3 or later, footnotes are now placed again at the end of each chapter. (#798, thanks @cderv) 
+
 - gitbook toolbar is not missing any more when rendering books with Pandoc 2.x and using `self_contained = TRUE` (thanks, @Pindar777, @RLesur, @cderv, #739).
 
 # CHANGES IN bookdown VERSION 0.14

--- a/R/html.R
+++ b/R/html.R
@@ -876,7 +876,7 @@ parse_footnotes = function(x) {
   j = which(x == '</div>')
   j = min(j[j > i])
   n = length(x)
-  r = '<li id="fn([0-9]+)"><p>.+?<a href="#fnref\\1"[^>]*?>.</a></p></li>'
+  r = '<li id="fn([0-9]+)"><p>.+?<a href="#fnref\\1"[^>]*?>.+</a></p></li>'
   s = paste(x[i:n], collapse = '\n')
   items = unlist(regmatches(s, gregexpr(r, s)))
   list(items = setNames(items, gsub(r, 'fn\\1', items)), range = i:j)


### PR DESCRIPTION
This fixes #793 

There was a change in pandoc where  the ⤶︎ was previously a single unicode `\u2936`, and now it is encoded in two unicode character `\u2936\uFE0E`. That breaks the regex that identify footnootes in html code. In regex, a dot `.` will only match one unicode, not two even if it is one. 
See example: 

``` r
grep(">.</a>", enc2utf8(">\u2936</a>"), value = TRUE)
#> [1] "><U+2936></a>"
grep(">.</a>", enc2utf8(">\u2936\uFE0E</a>"), value = TRUE)
#> character(0)
grep(">.+</a>", enc2utf8(">\u2936\uFE0E</a>"), value = TRUE)
#> [1] "><U+2936><U+FE0E></a>"
```

This is an easy fix to use `.+` instead of `.` - I used that for now.

This can also be handled using purl regex and special pattern `\X`. See [here](https://www.regular-expressions.info/unicode.html)
``` r
grep(">\\X</a>", enc2utf8(">\u2936</a>"), value = TRUE, perl = TRUE)
#> [1] "><U+2936></a>"
grep(">\\X</a>", enc2utf8(">\u2936\uFE0E</a>"), value = TRUE, perl = TRUE)
#> [1] "><U+2936><U+FE0E></a>"
```

Or directly using unicode pattern match.

``` r
grep(">\\x{2936}</a>", enc2utf8(">\u2936</a>"), value = TRUE, perl = TRUE)
#> [1] "><U+2936></a>"
grep(">\\x{2936}\\x{FE0E}</a>", enc2utf8(">\u2936\uFE0E</a>"), value = TRUE, perl = TRUE)
#> [1] "><U+2936><U+FE0E></a>"
```

@yihui, is the quick fix good enough for you or should we go with exact match ? 
