### PR TITLE
Correct fix for footnote unicode change in pandoc 2.7.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## BUG FIXES
 
-- When using pandoc 2.7.3 or later, footnotes are now placed again at the end of each chapter. (#798, thanks @cderv) 
+- When using pandoc 2.7.3 or later, footnotes are now placed again at the end of each chapter. (#798, #801, thanks @cderv) 
 
 - gitbook toolbar is not missing any more when rendering books with Pandoc 2.x and using `self_contained = TRUE` (thanks, @Pindar777, @RLesur, @cderv, #739).
 

--- a/R/html.R
+++ b/R/html.R
@@ -876,10 +876,10 @@ parse_footnotes = function(x) {
   j = which(x == '</div>')
   j = min(j[j > i])
   n = length(x)
-  r = '<li id="fn([0-9]+)"><p>.+?<a href="#fnref\\1"[^>]*?>.+</a></p></li>'
+  r = '<li id="fn([0-9]+)"><p>.+?<a href="#fnref\\1"[^>]*?>\\X</a></p></li>'
   s = paste(x[i:n], collapse = '\n')
-  items = unlist(regmatches(s, gregexpr(r, s)))
-  list(items = setNames(items, gsub(r, 'fn\\1', items)), range = i:j)
+  items = unlist(regmatches(s, gregexpr(r, s, perl = TRUE)))
+  list(items = setNames(items, gsub(r, 'fn\\1', items, perl = TRUE)), range = i:j)
 }
 
 # move footnotes to the relevant page

--- a/tests/rmd/parse-footnotes.Rmd
+++ b/tests/rmd/parse-footnotes.Rmd
@@ -10,6 +10,13 @@ output:
 
 Hello world.^[Hello world footnote.]
 
-## Subsection
+## Subsection footnotes 1
+
+```{block2, type = 'rmdtip'}
+  Another text with footnote^[second footnote]
+```
+
+## Subsection footnotes 2
 
 Something.
+

--- a/tests/test-rmd.R
+++ b/tests/test-rmd.R
@@ -9,7 +9,24 @@ if (Sys.getenv('NOT_CRAN') == 'true') local({
   for (f in list.files('rmd', '[.]Rmd$', full.names = TRUE)) {
     rmarkdown::render(f, envir = globalenv(), quiet = TRUE)
   }
+
   if (!any(readLines('rmd/equation-label.html') == 'y \\in \\mathbb{Z} \\tag{2}')) {
     stop('Failed to render the equation label in equation-label.Rmd')
+  }
+
+  # footnotes are parsed and moved correctly
+  ## deleted from last section
+  if (any(readLines("rmd/subsection-footnotes-2.html") == '<div class="footnotes">')) {
+    stop('Failed to parse and delete the footnotes in parse_footnotes.Rmd')
+  }
+  ## footnote one is moved to first section
+  if (!any(readLines('rmd/test-footnote.html') == '<div class="footnotes">') ||
+      !any(grepl('id="fn1"', readLines('rmd/test-footnote.html')))) {
+    stop('Failed to move the footnotes back to subsection 1 in parse_footnotes.Rmd')
+  }
+  ## footnote two is moved to second section
+  if (!any(readLines('rmd/subsection-footnotes-1.html') == '<div class="footnotes">') ||
+      !any(grepl('id="fn2"', readLines('rmd/subsection-footnotes-1.html')))) {
+    stop('Failed to move the footnotes back to subsection 1 in parse_footnotes.Rmd')
   }
 })


### PR DESCRIPTION
This complete the fix for #793 that was previously handled in #798 

The regex was not correct. I am really sorry for the quick fix that was not correct. handling html with regex is not a trivial task.

Instead, this time to be sure I propose to use the other method I find more robust : match exactly for a unicode char using perl regex and special pattern `\\X`. 

This will get correctly a named vectors of footnotes, with correct names so that relocation happens correctly even in special case (this closes #799)

It is difficult to really test completly the impact of those changes. 

@yihui , I am really sorry to PR some changes that are not fully vetted and properly tested. 

I think this one is now ok. I tested again the example in #799, with pandoc 2.7.2 and pandoc 2.7.3.

<details> <summary> Reprex code used to test </summary>

```r
# to execute from bookdown project
# download bundle
reprex_bundle <- "https://github.com/rstudio/bookdown/files/3804848/bookdown-demo-footnote_blocks.zip"
dir.create(temp_dir <- tempfile(pattern = "dir"))
old <- setwd(temp_dir)
xfun::download_file(reprex_bundle)
unzip("bookdown-demo-footnote_blocks.zip")
setwd("bookdown-demo-footnote_blocks")
list.files()
devtools::load_all(old)
packageVersion("bookdown")
old_path <- Sys.getenv("PATH")
# use pandoc 2.7.3, the default found in PATH
Sys.setenv(PATH = old_path)
# should find pandoc 2.7.3
(rmarkdown:::find_pandoc(cache = FALSE))
render_book("index.Rmd")
browseURL("_book/index.html")
# use pandoc 2.7.2, the one from RStudio
Sys.setenv(PATH = paste(Sys.getenv("RSTUDIO_PANDOC"), old_path, sep = ";"))
# should find pandoc 2.7.2
(rmarkdown:::find_pandoc(cache = FALSE))
render_book("index.Rmd")
browseURL("_book/index.html")
setwd(old)
# cleaning
unlink(temp_dir)
```

</details>