### PR TITLE
Update sharing urls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## BUG FIXES
 
+- Sharing to facebook and twitter is possible again. Google+ sharing has been disable (with a warning) as it no more exists. (thanks, @cderv, #802)
+
 - When using pandoc 2.7.3 or later, footnotes are now placed again at the end of each chapter. (#798, thanks @cderv) 
 
 - gitbook toolbar is not missing any more when rendering books with Pandoc 2.x and using `self_contained = TRUE` (thanks, @Pindar777, @RLesur, @cderv, #739).

--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -30,7 +30,7 @@ gitbook = function(
       ..., extra_dependencies = c(extra_dependencies, gitbook_dependency(table_css))
     )
   }
-  gb_config = config
+  gb_config = check_gb_config(config)
   if (identical(template, 'default')) {
     template = bookdown_file('templates', 'gitbook.html')
   }
@@ -229,7 +229,7 @@ gitbook_toc = function(x, cur, config) {
 gitbook_config = function(config = list()) {
   default = list(
     sharing = list(
-      facebook = TRUE, twitter = TRUE, google = FALSE,
+      facebook = TRUE, twitter = TRUE,
       linkedin = FALSE, weibo = FALSE, instapaper = FALSE, vk = FALSE,
       all = c('facebook', 'twitter', 'linkedin', 'weibo', 'instapaper')
     ),
@@ -283,4 +283,17 @@ download_filenames = function(config) {
     }
   }
   if (length(downloads)) I(downloads)
+}
+
+check_gb_config <- function(config) {
+  # to insure retrocompatibility with 0.14 and earlier
+  if (isTRUE(config[["sharing"]][["google"]]) ||
+      'google' %in% config[["sharing"]][["all"]]) {
+    warning("Sharing to Google+ is no more supported because it does not exist anymore.\n",
+            "Please update your configuration in `_output.yml`.",
+            call. = FALSE)
+    config[["sharing"]][["google"]] <- NULL
+    config[["sharing"]][["all"]] <- setdiff(config[["sharing"]][["all"]], 'google')
+  }
+  config
 }

--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -285,15 +285,15 @@ download_filenames = function(config) {
   if (length(downloads)) I(downloads)
 }
 
-check_gb_config <- function(config) {
-  # to insure retrocompatibility with 0.14 and earlier
+check_gb_config = function(config) {
+  # to ensure backward compatibility with 0.14 and earlier
   if (isTRUE(config[["sharing"]][["google"]]) ||
       'google' %in% config[["sharing"]][["all"]]) {
-    warning("Sharing to Google+ is no more supported because it does not exist anymore.\n",
+    warning("Sharing to Google+ is no longer supported because Google has shut down Google+.\n",
             "Please update your configuration in `_output.yml`.",
             call. = FALSE)
-    config[["sharing"]][["google"]] <- NULL
-    config[["sharing"]][["all"]] <- setdiff(config[["sharing"]][["all"]], 'google')
+    config[["sharing"]][["google"]] = NULL
+    config[["sharing"]][["all"]] = setdiff(config[["sharing"]][["all"]], "google")
   }
   config
 }

--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -229,9 +229,9 @@ gitbook_toc = function(x, cur, config) {
 gitbook_config = function(config = list()) {
   default = list(
     sharing = list(
-      github = FALSE, facebook = TRUE, twitter = TRUE, google = FALSE,
+      facebook = TRUE, twitter = TRUE, google = FALSE,
       linkedin = FALSE, weibo = FALSE, instapaper = FALSE, vk = FALSE,
-      all = c('facebook', 'google', 'twitter', 'linkedin', 'weibo', 'instapaper')
+      all = c('facebook', 'twitter', 'linkedin', 'weibo', 'instapaper')
     ),
     fontsettings = list(theme = 'white', family = 'sans', size = 2),
     edit = list(link = NULL, text = NULL),

--- a/inst/examples/03-formats.Rmd
+++ b/inst/examples/03-formats.Rmd
@@ -105,12 +105,11 @@ bookdown::gitbook:
       facebook: yes
       github: no
       twitter: yes
-      google: no
       linkedin: no
       weibo: no
       instapaper: no
       vk: no
-      all: ['facebook', 'google', 'twitter', 'linkedin', 'weibo', 'instapaper']
+      all: ['facebook', 'twitter', 'linkedin', 'weibo', 'instapaper']
 ```
 
 The `toc` option controls the behavior of the table of contents (TOC). You can collapse some items initially when a page is loaded via the `collapse` option. Its possible values are `subsection`, `section`, `none` (or `null`). This option can be helpful if your TOC is very long and has more than three levels of headings: `subsection` means collapsing all TOC items for subsections (X.X.X), `section` means those items for sections (X.X) so only the top-level headings are displayed initially, and `none` means not collapsing any items in the TOC. For those collapsed TOC items, you can toggle their visibility by clicking their parent TOC items. For example, you can click a chapter title in the TOC to show/hide its sections.
@@ -173,7 +172,7 @@ You can also write it as:
 
 Each vector in the list consists of the filename and the text to be displayed in the menu. Compared to the first form, this form allows you to customize the menu text, e.g., you may have two different copies of the PDF for readers to download and you will need to make the menu items different.
 
-On the right of the toolbar, there are some buttons to share the link on social network websites such as Twitter, Facebook, and Google+. You can use the `sharing` option to decide which buttons to enable. If you want to get rid of these buttons entirely, use `sharing: null` (or `no`).
+On the right of the toolbar, there are some buttons to share the link on social network websites such as Twitter, Facebook, and Linkedin. You can use the `sharing` option to decide which buttons to enable. If you want to get rid of these buttons entirely, use `sharing: null` (or `no`).
 
 Finally, there are a few more top-level options in the YAML metadata that can be passed to the GitBook HTML template via Pandoc. They may not have clear visible effects on the HTML output, but they may be useful when you deploy the HTML output as a website. These options include:
 

--- a/inst/resources/gitbook/js/plugin-sharing.js
+++ b/inst/resources/gitbook/js/plugin-sharing.js
@@ -26,14 +26,6 @@ gitbook.require(["gitbook", "lodash", "jQuery"], function(gitbook, _, $) {
                 window.open("http://twitter.com/home?status="+encodeURIComponent(document.title+" "+location.href));
             }
         },
-        'google': {
-            'label': 'Google+',
-            'icon': 'fa fa-google-plus',
-            'onClick': function(e) {
-                e.preventDefault();
-                window.open("https://plus.google.com/share?url="+encodeURIComponent(location.href));
-            }
-        },
         'linkedin': {
             'label': 'LinkedIn',
             'icon': 'fa fa-linkedin',

--- a/inst/resources/gitbook/js/plugin-sharing.js
+++ b/inst/resources/gitbook/js/plugin-sharing.js
@@ -15,7 +15,7 @@ gitbook.require(["gitbook", "lodash", "jQuery"], function(gitbook, _, $) {
             'icon': 'fa fa-facebook',
             'onClick': function(e) {
                 e.preventDefault();
-                window.open("http://www.facebook.com/sharer/sharer.php?s=100&p[url]="+encodeURIComponent(location.href));
+                window.open("http://www.facebook.com/sharer/sharer.php?u="+encodeURIComponent(location.href));
             }
         },
         'twitter': {

--- a/inst/resources/gitbook/js/plugin-sharing.js
+++ b/inst/resources/gitbook/js/plugin-sharing.js
@@ -23,7 +23,7 @@ gitbook.require(["gitbook", "lodash", "jQuery"], function(gitbook, _, $) {
             'icon': 'fa fa-twitter',
             'onClick': function(e) {
                 e.preventDefault();
-                window.open("http://twitter.com/home?status="+encodeURIComponent(document.title+" "+location.href));
+                window.open("http://twitter.com/intent/tweet?text="+document.title+"&url="+encodeURIComponent(location.href)+"&hashtags=rmarkdown,bookdown");
             }
         },
         'linkedin': {

--- a/inst/resources/gitbook/js/plugin-sharing.js
+++ b/inst/resources/gitbook/js/plugin-sharing.js
@@ -44,7 +44,7 @@ gitbook.require(["gitbook", "lodash", "jQuery"], function(gitbook, _, $) {
         },
         'instapaper': {
             'label': 'Instapaper',
-            'icon': 'fa fa-instapaper',
+            'icon': 'fa fa-italic',
             'onClick': function(e) {
                 e.preventDefault();
                 window.open("http://www.instapaper.com/text?u="+encodeURIComponent(location.href));


### PR DESCRIPTION
This closes #797 

As explained in https://github.com/rstudio/bookdown/issues/797#issuecomment-549181261 there was changes in sharing url. 

This PR: 

* removes google+ as it does not exist anymore. 
* updates sharing link for twitter and facebook
* changes icon for instapaper as `fa-instapaper` does not exists.

`fa-italic`
![image](https://user-images.githubusercontent.com/6791940/68167155-d8c34880-ff64-11e9-9809-428b19a5c0dd.png)

Instapaper icone 
![image](https://user-images.githubusercontent.com/6791940/68167229-1c1db700-ff65-11e9-9523-cee7b45aa117.png)

## About google removal

Google sharing is removed from example and default value. 
A new function `check_gb_config` is here to check configuration and change user's config with a warning to disable some option. (here remove google from `sharing` list or `all` vector

I think this is enough to not break older bookdown where `google` would have been present in configuration. 

We could also leave as is and the sharing link would redirect to google+ removal page
https://plus.google.com/

See for example https://bookdown.org/yihui/bookdown/ and sharing link to google plus.