### PR TITLE
add a view button to gitbook toolbar

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,7 @@ Authors@R: c(
     person("Jennifer", "Bryan", role = "ctb"),
     person("Jonathan", "McPhers", role = "ctb"),
     person("JooYoung", "Seo", role="ctb", comment = c(ORCID = "0000-0002-4064-6012")),
+    person("Joyce", "Robbins", role = "ctb"),
     person("Junwen", "Huang", role = "ctb"),
     person("Kevin", "Cheung", role = "ctb"),
     person("Kevin", "Ushey", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CHANGES IN bookdown VERSION 0.16
 
+## NEW FEATURES
+
+- You can also add a "view" button on the GitBook toolbar, similar to the "edit" and "history" buttons, which shows the page's `.Rmd` source file on GitHub. Unlike "edit", "view" does not require the reader to login to GitHub and fork the repo (thanks, @jtr13, #806).
 
 # CHANGES IN bookdown VERSION 0.15
 

--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -155,7 +155,7 @@ gitbook_page = function(
   }
 
   # you can set the edit setting in either _bookdown.yml or _output.yml
-  for (type in c('edit', 'history')) {
+  for (type in c('edit', 'history', 'view')) {
     if (is.list(setting <- source_link_setting(config[[type]], type = type)))
       config[[type]] = setting
     if (length(rmd_cur) && is.list(config[[type]]))
@@ -236,6 +236,7 @@ gitbook_config = function(config = list()) {
     fontsettings = list(theme = 'white', family = 'sans', size = 2),
     edit = list(link = NULL, text = NULL),
     history = list(link = NULL, text = NULL),
+    view = list(link = NULL, text = NULL),
     download = NULL,
     # toolbar = list(position = 'static'),
     toc = list(collapse = 'subsection')

--- a/R/html.R
+++ b/R/html.R
@@ -191,6 +191,7 @@ build_chapter = function(
     button_link(link_prev, 'Previous'),
     source_link(rmd_cur, type = 'edit'),
     source_link(rmd_cur, type = 'history'),
+    source_link(rmd_cur, type = 'view'),
     button_link(link_next, 'Next'),
     '</p>',
     '</div>',

--- a/inst/examples/03-formats.Rmd
+++ b/inst/examples/03-formats.Rmd
@@ -144,7 +144,7 @@ The second button on the toolbar is the search button. Its keyboard shortcut is 
 
 The third button is for font/theme settings. You can change the font size (bigger or smaller), the font family (serif or sans serif), and the theme (`White`, `Sepia`, or `Night`). These settings can be changed via the `fontsettings` option.
 
-The `edit` option is the same as the option mentioned in Section \@ref(configuration). If it is not empty, an edit button will be added to the toolbar. This was designed for potential contributors to the book to contribute by editing the book on GitHub after clicking the button and sending pull requests.  The `history` option works the same
+The `edit` option is the same as the option mentioned in Section \@ref(configuration). If it is not empty, an edit button will be added to the toolbar. This was designed for potential contributors to the book to contribute by editing the book on GitHub after clicking the button and sending pull requests.  The `history` and `view` options work the same
 way.
 
 If your book has other output formats for readers to download, you may provide the `download` option so that a download button can be added to the toolbar. This option takes either a character vector, or a list of character vectors with the length of each vector being 2. When it is a character vector, it should be either a vector of filenames, or filename extensions, e.g., both of the following settings are okay:

--- a/inst/examples/04-customization.Rmd
+++ b/inst/examples/04-customization.Rmd
@@ -203,6 +203,7 @@ We have mentioned `rmd_files` in Section \@ref(usage), and there are more (optio
 - `after_chapter_script`: similar to `before_chapter_script`, and the R script is executed after each chapter.
 - `edit`: a link that collaborators can click to edit the Rmd source document of the current page; this was designed primarily for GitHub repositories, since it is easy to edit arbitrary plain-text files on GitHub even in other people's repositories (if you do not have write access to the repository, GitHub will automatically fork it and let you submit a pull request after you finish editing the file). This link should have `%s` in it, which will be substituted by the actual Rmd filename for each page.
 -  `history`: similar to `edit`, a link to the edit/commit history of the current page.
+-  `view`: similar to `edit`, a link to source code of the current page. 
 - `rmd_subdir`: whether to search for book source Rmd files in subdirectories (by default, only the root directory is searched). This may be either a boolean (e.g. `true` will search for book source Rmd files in the project directory and all subdirectories) or list of paths if you want to search for book source Rmd files in a subset of subdirectories.
 - `output_dir`: the output directory of the book (`_book` by default); this setting is read and used by `render_book()`.
 - `clean`: a vector of files and directories to be cleaned by the `clean_book()` function.
@@ -213,6 +214,7 @@ Here is a sample `_bookdown.yml`:
 book_filename: "my-book.Rmd"
 before_chapter_script: ["script1.R", "script2.R"]
 after_chapter_script: "script3.R"
+view: https://github.com/rstudio/bookdown-demo/blob/master/%s
 edit: https://github.com/rstudio/bookdown-demo/edit/master/%s
 output_dir: "book-output"
 clean: ["my-book.bbl", "R-packages.bib"]

--- a/inst/resources/gitbook/js/plugin-bookdown.js
+++ b/inst/resources/gitbook/js/plugin-bookdown.js
@@ -32,7 +32,7 @@ gitbook.require(["gitbook", "lodash", "jQuery"], function(gitbook, _, $) {
     var view = config.view;
     if (view && view.link) gitbook.toolbar.createButton({
       icon: 'fa fa-eye',
-      label: view.text || 'View',
+      label: view.text || 'View Source',
       position: 'left',
       onClick: function(e) {
         e.preventDefault();

--- a/inst/resources/gitbook/js/plugin-bookdown.js
+++ b/inst/resources/gitbook/js/plugin-bookdown.js
@@ -28,6 +28,18 @@ gitbook.require(["gitbook", "lodash", "jQuery"], function(gitbook, _, $) {
       }
     });
 
+        // add the View button (file view on Github)
+    var view = config.view;
+    if (view && view.link) gitbook.toolbar.createButton({
+      icon: 'fa fa-eye',
+      label: view.text || 'View',
+      position: 'left',
+      onClick: function(e) {
+        e.preventDefault();
+        window.open(view.link);
+      }
+    });
+
     // add the Download button
     var down = config.download;
     var normalizeDownload = function() {


### PR DESCRIPTION
This closes #805. I followed the model of pull request #639 Add option for a `history` button.