### PR TITLE
TOC collapse by section works with accents in chapter html filename

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 - For the `gitbook` output format, disabling the `sharing` menu or buttons works again (thanks, @lwjohnst86, #812).
 
+- For the `gitbook` output format, toc collapsed by section now works with accents in chapter titles (thanks, @glimmerphoenix, @cderv, #819) 
+
 # CHANGES IN bookdown VERSION 0.15
 
 ## BUG FIXES

--- a/inst/resources/gitbook/js/plugin-bookdown.js
+++ b/inst/resources/gitbook/js/plugin-bookdown.js
@@ -28,7 +28,7 @@ gitbook.require(["gitbook", "lodash", "jQuery"], function(gitbook, _, $) {
       }
     });
 
-        // add the View button (file view on Github)
+    // add the View button (file view on Github)
     var view = config.view;
     if (view && view.link) gitbook.toolbar.createButton({
       icon: 'fa fa-eye',
@@ -97,6 +97,8 @@ gitbook.require(["gitbook", "lodash", "jQuery"], function(gitbook, _, $) {
     // highlight the current section in TOC
     var href = window.location.pathname;
     href = href.substr(href.lastIndexOf('/') + 1);
+    // accentuated characters need to be decoded (#819)
+    href = decodeURI(href);
     if (href === '') href = 'index.html';
     var li = $('a[href^="' + href + location.hash + '"]').parent('li.chapter').first();
     var summary = $('ul.summary'), chaps = summary.find('li.chapter');

--- a/inst/resources/gitbook/js/plugin-bookdown.js
+++ b/inst/resources/gitbook/js/plugin-bookdown.js
@@ -98,7 +98,7 @@ gitbook.require(["gitbook", "lodash", "jQuery"], function(gitbook, _, $) {
     var href = window.location.pathname;
     href = href.substr(href.lastIndexOf('/') + 1);
     // accentuated characters need to be decoded (#819)
-    href = decodeURI(href);
+    href = decodeURIComponent(href);
     if (href === '') href = 'index.html';
     var li = $('a[href^="' + href + location.hash + '"]').parent('li.chapter').first();
     var summary = $('ul.summary'), chaps = summary.find('li.chapter');


### PR DESCRIPTION
This will fix #819 

When there is some special characters (like accentuated ones) in chapter titles, the default `split_by: chapter` will create several html file with the a name like the chapter title. 

Example from bookdown demo: 
* `litérature.html` in French if you put `# Litérature` in file `02-literature.Rmd`

In this case, as described in #819, there is an issue in the TOC. This is because 
https://github.com/rstudio/bookdown/blob/cc9dcecbfe510ea01eefc8d8651662b9164fb25b/inst/resources/gitbook/js/plugin-bookdown.js#L98-L99
will get you url encode filename
```js
var href = window.location.pathname;
href = href.substr(href.lastIndexOf('/') + 1);
href
> "lit%C3%A9rature.html"
```
All the JS logic afterward is broken because it will compare this href with some attributes and even use it as attributes in some Jquery selection. it should be `href = litérature.html` instead.
Example: 
* This won't select the `li` corresponding to `litérature.html`
https://github.com/rstudio/bookdown/blob/cc9dcecbfe510ea01eefc8d8651662b9164fb25b/inst/resources/gitbook/js/plugin-bookdown.js#L101
* This won't be equal to true where it should
https://github.com/rstudio/bookdown/blob/cc9dcecbfe510ea01eefc8d8651662b9164fb25b/inst/resources/gitbook/js/plugin-bookdown.js#L131

The easy solution in JS I suggest here is to consider that `window.location.pathname` should be url-decoded before processing. 

The other solution is more deeply in bookdown code: **Bookdown could consider that there should not be any special characters in filenames**. This would mean that `split_chapter` should be modified to not create `litérature.html`  but `literature.html` even in accent in the chapter title. 
However, I think this could lead to more breakage as it would require to handle filename reference without any special character different from chapter name in toc and body with accentuated character. It seems more complicated. 

This modification is not easy to test. I just played with bookdown demo and special title.

@yihui I let you look into this and see for yourself if the JS fix seems enough or there should be a better logic  used for accentuated chapter title in bookdown. 
