### PR TITLE
Added github_document2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # CHANGES IN bookdown VERSION 0.17
 
+## NEW FEATURES
+
+- Added `github_document2`.
+
 ## BUG FIXES
 
 - For output formats like `pdf_book`, unused arguments passed to `base_format` will be discarded (thanks, @jooyoungseo, #790).

--- a/R/word.R
+++ b/R/word.R
@@ -28,8 +28,8 @@ markdown_document2 = function(
 
 #' @rdname html_document2
 #' @export
-word_document2 = function(...) {
-  markdown_document2(..., base_format = rmarkdown::word_document)
+github_document2 = function(...) {
+  markdown_document2(..., base_format = rmarkdown::github_document)
 }
 
 #' @rdname html_document2
@@ -48,4 +48,10 @@ powerpoint_presentation2 = function(...) {
 #' @export
 rtf_document2 = function(...) {
   markdown_document2(..., base_format = rmarkdown::rtf_document)
+}
+
+#' @rdname html_document2
+#' @export
+word_document2 = function(...) {
+  markdown_document2(..., base_format = rmarkdown::word_document)
 }


### PR DESCRIPTION
# Changes

* This PR makes it easier for those who use similar approach mentioned in #782.
* Added `github_document2` on top of `rmarkdown::github_document`.
* Reordered functions in `R/word.R` alphabetically.

# Testing

The following works without any issues:

````
---
output: bookdown::github_document2
---

# Table Test

See Table\ \@ref(tab:test-table).

```{r test-table}
knitr::kable(head(airquality), caption = "Test table.")
```

---

# Figure Test

See Figure \@ref(fig:test-figure).

```{r test-figure, fig.cap="Figure test."}
hist(airquality$Ozone, col="blue")
```
````