### PR TITLE
Added context_document2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,7 +61,7 @@ License: GPL-3
 Imports:
     htmltools (>= 0.3.6),
     knitr (>= 1.22),
-    rmarkdown (>= 1.12),
+    rmarkdown (>= 2.0),
     xfun (>= 0.6),
     tinytex (>= 0.12)
 Suggests:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # CHANGES IN bookdown VERSION 0.18
 
+## NEW FEATURES
+
+- Added an output format `context_document2`, based on the newly developed `rmarkdown::context_document` (see rstudio/rmarkdown#1713, rstudio/rmarkdown#1715, and rstudio/rmarkdown#1725; thanks @jooyoungseo, @atusy, and @RLesur).
+
 ## BUG FIXES
 
 - `render_book()` works correctly with `output_dir = "."` now (thanks, @julianre, @cderv, #857).

--- a/R/word.R
+++ b/R/word.R
@@ -28,6 +28,12 @@ markdown_document2 = function(
 
 #' @rdname html_document2
 #' @export
+context_document2 = function(...) {
+  markdown_document2(..., base_format = rmarkdown::context_document)
+}
+
+#' @rdname html_document2
+#' @export
 github_document2 = function(...) {
   markdown_document2(..., base_format = rmarkdown::github_document)
 }


### PR DESCRIPTION
I have confirmed the following works without any issues:

`test.Rmd`:

````
---
output: bookdown::context_document2
---

```{r test, echo=FALSE}
library(knitr)
```

# Table Test

See Table\ \@ref(tab:test-table).

```{r test-table}
knitr::kable(head(airquality), caption = "Test table.")
```

---

# Figure Test

See Figure \@ref(fig:test-figure).

```{r test-figure, fig.cap="Figure test."}
hist(airquality$Ozone, col="blue")
```
````