### PR TITLE
Fix cross referencing when spliting by sections

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CHANGES IN bookdown VERSION 0.18
 
+## BUG FIXES
+
+- Cross-referencing works correctly now with `gitbook` when using `split_by: section` or `split_by: section+number` (thanks, @ThierryO, @cderv, #787)
 
 # CHANGES IN bookdown VERSION 0.17
 

--- a/R/html.R
+++ b/R/html.R
@@ -281,7 +281,7 @@ split_chapters = function(output, build = build_chapter, number_sections, split_
       # close the h1 section early with </div>
       # reg_chap and sec_num must take this into account so that cross reference
       # works when split by section. (#849)
-      if (length(i)) x[i] = paste(x[i], '\n</div>')
+      if (length(i)) x[i] = paste0(x[i], '\n</div>')
       # h1 that immediately follows h2 but not the first h1
       i = n12 == 'h1' & c('h1', head(n12, -1)) == 'h2'
       if (any(i) && n12[1] == 'h2') i[which(n12 == 'h1')[1]] = FALSE
@@ -577,7 +577,7 @@ prefix_section_labels = function(labels) {
   labels
 }
 
-reg_chap = '^(<h1><span class="header-section-number">)([A-Z0-9]+)(</span>.+</h1>)( \n</div>)?$'
+reg_chap = '^(<h1><span class="header-section-number">)([A-Z0-9]+)(</span>.+</h1>)(\n</div>)?$'
 
 # default names for labels
 label_names = list(fig = 'Figure ', tab = 'Table ', eq = 'Equation ')
@@ -692,7 +692,7 @@ i18n = function(group, key, dict = list()) {
   if (is.null(labels[[key]])) dict[[key]] else labels[[key]]
 }
 
-sec_num = '^<h[1-6]><span class="header-section-number">([.A-Z0-9]+)</span>.+</h[1-6]>( \n</div>)?$'
+sec_num = '^<h[1-6]><span class="header-section-number">([.A-Z0-9]+)</span>.+</h[1-6]>(\n</div>)?$'
 
 # parse section numbers and labels (id's)
 parse_section_labels = function(content) {

--- a/R/html.R
+++ b/R/html.R
@@ -279,6 +279,8 @@ split_chapters = function(output, build = build_chapter, number_sections, split_
       # h2 that immediately follows h1
       i = h12[n12 == 'h2' & c('h2', head(n12, -1)) == 'h1'] - 1
       # close the h1 section early with </div>
+      # reg_chap and sec_num must take this into account so that cross reference
+      # works when split by section. (#849)
       if (length(i)) x[i] = paste(x[i], '\n</div>')
       # h1 that immediately follows h2 but not the first h1
       i = n12 == 'h1' & c('h1', head(n12, -1)) == 'h2'

--- a/R/html.R
+++ b/R/html.R
@@ -575,7 +575,7 @@ prefix_section_labels = function(labels) {
   labels
 }
 
-reg_chap = '^(<h1><span class="header-section-number">)([A-Z0-9]+)(</span>.+</h1>)$'
+reg_chap = '^(<h1><span class="header-section-number">)([A-Z0-9]+)(</span>.+</h1>)( \n</div>)?$'
 
 # default names for labels
 label_names = list(fig = 'Figure ', tab = 'Table ', eq = 'Equation ')
@@ -690,7 +690,7 @@ i18n = function(group, key, dict = list()) {
   if (is.null(labels[[key]])) dict[[key]] else labels[[key]]
 }
 
-sec_num = '^<h[1-6]><span class="header-section-number">([.A-Z0-9]+)</span>.+</h[1-6]>$'
+sec_num = '^<h[1-6]><span class="header-section-number">([.A-Z0-9]+)</span>.+</h[1-6]>( \n</div>)?$'
 
 # parse section numbers and labels (id's)
 parse_section_labels = function(content) {

--- a/tests/rmd/split-section.Rmd
+++ b/tests/rmd/split-section.Rmd
@@ -6,10 +6,22 @@ output:
     split_by: section
 ---
 
-# Section 1 
+# Section 1
 
 Some content
 
 ## subsection 1
 
 Hello.
+
+See chapter 2 now at \@ref(section-2)
+
+# Section 2
+
+## subsection 2 {#sub2}
+
+```{r iris-plot, fig.cap = "A plot"}
+plot(iris)
+```
+
+See figure \@ref(fig:iris-plot)

--- a/tests/test-rmd.R
+++ b/tests/test-rmd.R
@@ -10,6 +10,18 @@ if (Sys.getenv('NOT_CRAN') == 'true') local({
     rmarkdown::render(f, envir = globalenv(), quiet = TRUE)
   }
 
+  # split by section works correctly
+  ## id is used for html file name
+  sections_files <- c("section-1.html", "subsection-1.html", "section-2.html", "sub2.html")
+  if (any(!file.exists(file.path("rmd", sections_files))))
+    stop("Failed to generate sections files")
+  ## reference is working correctly (see #787)
+  if (!any(xfun::read_utf8("rmd/subsection-1.html") == '<p>See chapter 2 now at <a href="section-2.html#section-2">2</a></p>'))
+    stop('Failed to reference section when split by sections')
+  if (!any(xfun::read_utf8("rmd/sub2.html") == '<p>See figure <a href="sub2.html#fig:iris-plot">2.1</a></p>'))
+    stop('Failed to reference figure when split by sections')
+
+  # Check equation label are working
   if (!any(readLines('rmd/equation-label.html') == 'y \\in \\mathbb{Z} \\tag{2}')) {
     stop('Failed to render the equation label in equation-label.Rmd')
   }


### PR DESCRIPTION
This will fixes #787 

To understand what does not work currently, here is a `index.Rmd` to reproduce
````r
---
title: "My book"
site: bookdown::bookdown_site
output:
  bookdown::gitbook: 
    split_by: "section"
---

# Cross-references {-}

| Target | Label |
| ------ | ----- |
| Chapter 1 | \@ref(chapter-1) |
| Section 1.1 | \@ref(s:1:1) |

# Chapter 1

## Section 1.1 {#s:1:1}

```{r iris-plot, fig.cap="A plot"}
plot(iris)
```

See figure \@ref(fig:iris-plot)
````

When using `split_by: sections` , a _h2_ following a _h1_ with no content in between will broke the section reference, and will create an incorrect number in figure reference. 
You'll get a 
```r
Warning message:
The label(s) chapter-1 not found
```

This is because bookdown processing will add a closing `div` tag, to support special bookdown feature, when `split_by`  is `section` or `section+number`
https://github.com/rstudio/bookdown/blob/70f9c07b2049f772b377956047421172069193d9/R/html.R#L282

When the second header follows directly the first header (i.e `x[i]` would be this `h1` header), it will add this closing ` \n</div>` to the end of the h1 header. This will break `parse_section_labels()` that won't find the id because the regex does not take into account this addition. 
https://github.com/rstudio/bookdown/blob/70f9c07b2049f772b377956047421172069193d9/R/html.R#L700-L707

This PR fixes this by detecting the extra div added when split by sections. 
Also, I added some tests to check that it will continue to work in the future.
