### PR TITLE
ignore a NULL output_dir when cleaning empty directory

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,10 +2,9 @@
 
 ## BUG FIXES
 
-- `render_book` now handles correctly when `output_dir` is set to current
-working directory i.e `output_dir = "."` (thanks, @julianre, @cderv, #857)
+- `render_book()` works correctly with `output_dir = "."` now (thanks, @julianre, @cderv, #857).
 
-- Cross-referencing works correctly now with `gitbook` when using `split_by: section` or `split_by: section+number` (thanks, @ThierryO, @cderv, #787)
+- Cross-referencing works correctly now with `gitbook` when using `split_by: section` or `split_by: section+number` (thanks, @ThierryO, @cderv, #787).
 
 - When using the Knit-and-Merge approach to compile a book (`new_session: true` in `_bookdown.yml`) and the fields `before_chapter_script` and/or `after_chapter_script` are configured in `_bookdown.yml`, the original Rmd files are no longer touched (thanks, @clauswilke #405 and @bob-carpenter https://stackoverflow.com/q/50554196/559676), and the scripts specified in `before/after_chapter_script` are no longer inserted into the Rmd files (they are read and evaluated separately), so the line numbers will be correct in case of **knitr** errors (thanks, @arencambre, #852).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## BUG FIXES
 
+- `render_book` now handles correctly when `output_dir` is set to current
+working directory i.e `output_dir = "."` (thanks, @julianre, @cderv, #857)
+
 - Cross-referencing works correctly now with `gitbook` when using `split_by: section` or `split_by: section+number` (thanks, @ThierryO, @cderv, #787)
 
 - When using the Knit-and-Merge approach to compile a book (`new_session: true` in `_bookdown.yml`) and the fields `before_chapter_script` and/or `after_chapter_script` are configured in `_bookdown.yml`, the original Rmd files are no longer touched (thanks, @clauswilke #405 and @bob-carpenter https://stackoverflow.com/q/50554196/559676), and the scripts specified in `before/after_chapter_script` are no longer inserted into the Rmd files (they are read and evaluated separately), so the line numbers will be correct in case of **knitr** errors (thanks, @arencambre, #852).

--- a/R/utils.R
+++ b/R/utils.R
@@ -103,7 +103,7 @@ mark_dirs = function(x) {
 }
 
 clean_empty_dir = function(dir) {
-  if (!dir_exists(dir)) return()
+  if (is.null(dir) || !dir_exists(dir)) return()
   files = list.files(dir, all.files = TRUE, recursive = TRUE)
   if (length(files) == 0) unlink(dir, recursive = TRUE)
 }

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -52,17 +52,17 @@ assert('prepend_chapter_title() adds the chapter title to the page title', {
       '<title>chapter one | asdf qwer</title><meta property="og:title" content="chapter one | asdf qwer" />')
 })
 
-assert("correctly clean empty dir if required", {
-       # do nothing is NULL (#857)
-       (clean_empty_dir(NULL) %==% NULL)
-       # remove if empty
-       dir.create(temp_dir <- tempfile())
-       clean_empty_dir(temp_dir)
-       (dir_exists(temp_dir) %==% FALSE)
-       # do not remove if not empty
-       dir.create(temp_dir <- tempfile())
-       writeLines("test", tempfile(tmpdir = temp_dir))
-       (clean_empty_dir(temp_dir) %==% NULL)
-       (dir_exists(temp_dir) %==% TRUE)
-       unlink(temp_dir, recursive = TRUE)
-       })
+assert('correctly clean empty dir if required', {
+  # do nothing is NULL (#857)
+  (clean_empty_dir(NULL) %==% NULL)
+  # remove if empty
+  dir.create(temp_dir <- tempfile())
+  clean_empty_dir(temp_dir)
+  (dir_exists(temp_dir) %==% FALSE)
+  # do not remove if not empty
+  dir.create(temp_dir <- tempfile())
+  writeLines('test', tempfile(tmpdir = temp_dir))
+  (clean_empty_dir(temp_dir) %==% NULL)
+  (dir_exists(temp_dir) %==% TRUE)
+  unlink(temp_dir, recursive = TRUE)
+})

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -51,3 +51,18 @@ assert('prepend_chapter_title() adds the chapter title to the page title', {
   (prepend_chapter_title(h, '<h1>chapter one</h1>')  %==%
       '<title>chapter one | asdf qwer</title><meta property="og:title" content="chapter one | asdf qwer" />')
 })
+
+assert("correctly clean empty dir if required", {
+       # do nothing is NULL (#857)
+       (clean_empty_dir(NULL) %==% NULL)
+       # remove if empty
+       dir.create(temp_dir <- tempfile())
+       clean_empty_dir(temp_dir)
+       (dir_exists(temp_dir) %==% FALSE)
+       # do no remove if not empty
+       dir.create(temp_dir <- tempfile())
+       writeLines("test", tempfile(tmpdir = temp_dir))
+       (clean_empty_dir(temp_dir) %==% NULL)
+       (dir_exists(temp_dir) %==% TRUE)
+       unlink(temp_dir, recursive = TRUE)
+       })

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -59,7 +59,7 @@ assert("correctly clean empty dir if required", {
        dir.create(temp_dir <- tempfile())
        clean_empty_dir(temp_dir)
        (dir_exists(temp_dir) %==% FALSE)
-       # do no remove if not empty
+       # do not remove if not empty
        dir.create(temp_dir <- tempfile())
        writeLines("test", tempfile(tmpdir = temp_dir))
        (clean_empty_dir(temp_dir) %==% NULL)


### PR DESCRIPTION
This will fix #857 

Currently in `render_book`, when `output_dir = "."`, it will be set internally to `NULL` as bookdown will ignore it in several places
https://github.com/rstudio/bookdown/blob/581bb639b273a5872e01c10d382065a80a641bf0/R/utils.R#L82-L94

Currently, `clean_empty_dir` throws an error when `output_dir` is NULL
https://github.com/rstudio/bookdown/blob/581bb639b273a5872e01c10d382065a80a641bf0/R/render.R#L78-L79

With this PR, `clean_empty_dir` will also ignore `output_dir = NULL`as the current working directory will not be empty and we don't want to remove it anyway. 

From my understanding, `dir` could be NULL for `clean_empty_dir` only in this special case, as otherwise `output_dirname()` will have resolved differently.

This PR also adds tests for this utils function. 
 