### PR TITLE
Multiline footnote are now correctly parsed again

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # CHANGES IN bookdown VERSION 0.19
 
+- Multiline footnotes are now correctly rendered in HTML output (thanks, @jtbayly,  @cderv, #876)
 
 # CHANGES IN bookdown VERSION 0.18
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # CHANGES IN bookdown VERSION 0.19
 
-- Multiline footnotes are now correctly rendered in HTML output (thanks, @jtbayly,  @cderv, #876)
+## BUG FIXES
+
+- Multiline footnotes are now correctly rendered in HTML output (thanks, @jtbayly,  @cderv, #876).
 
 # CHANGES IN bookdown VERSION 0.18
 

--- a/R/html.R
+++ b/R/html.R
@@ -946,7 +946,7 @@ parse_footnotes = function(x) {
   j = which(x == '</div>')
   j = min(j[j > i])
   n = length(x)
-  r = '<li id="fn([0-9]+)"><p>.+?<a href="#fnref\\1"[^>]*?>\\X</a></p></li>'
+  r = '<li id="fn([0-9]+)"><p>(?s).+?<a href="#fnref\\1"[^>]*?>\\X</a></p></li>'
   s = paste(x[i:n], collapse = '\n')
   items = unlist(regmatches(s, gregexpr(r, s, perl = TRUE)))
   list(items = setNames(items, gsub(r, 'fn\\1', items, perl = TRUE)), range = i:j)

--- a/tests/rmd/parse-footnotes.Rmd
+++ b/tests/rmd/parse-footnotes.Rmd
@@ -16,6 +16,9 @@ Hello world.^[Hello world footnote.]
   Another text with footnote^[second footnote]
 ```
 
+A text^[with a multi line 
+footnote]
+
 ## Subsection footnotes 2
 
 Something.

--- a/tests/test-rmd.R
+++ b/tests/test-rmd.R
@@ -41,4 +41,9 @@ if (Sys.getenv('NOT_CRAN') == 'true') local({
       !any(grepl('id="fn2"', readLines('rmd/subsection-footnotes-1.html')))) {
     stop('Failed to move the footnotes back to subsection 1 in parse_footnotes.Rmd')
   }
+  # multiline footnote is also moved
+  if (!any(readLines('rmd/subsection-footnotes-1.html') == '<div class="footnotes">') ||
+      !any(grepl('id="fn3"', readLines('rmd/subsection-footnotes-1.html')))) {
+    stop('Failed to move the footnotes back to subsection 1 in parse_footnotes.Rmd')
+  }
 })


### PR DESCRIPTION
This fixes #840 

Newline character was not correctly parsed in the regex pattern as by default in PCRE a dot matches all except newline character. Adding the modifier changes this. 