### PR TITLE
correcly get source files when rmd_files and rmd_subdir are provided

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,11 @@
 
 - Text references do not work for `theorem` environments (thanks, @ssp3nc3r, rstudio/tufte#75).
 
-- when `rmd_subdir` and `rmd_files` are provided, only the `rmd_files` are now selected in addition to the `rmd_subdir` content. (thanks, @Gnossos, @cderv, #885).
+- When both `rmd_subdir` and `rmd_files` are provided in the config file `_bookdown.yml`, only the files specified in `rmd_files` are now selected in addition to files under `rmd_subdir`. In the previous version, all files under the root directory are selected (thanks, @Gnossos #885, @cderv #886).
+
+## MAJOR CHANGES
+
+- Files with a leading `_` in their names are always ignored, even if they are specified in `rmd_files` in `_bookdown.yml`. Such files under subdirectories are also always ignored (#886).
 
 # CHANGES IN bookdown VERSION 0.18
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 - Text references do not work for `theorem` environments (thanks, @ssp3nc3r, rstudio/tufte#75).
 
+- when `rmd_subdir` and `rmd_files` are provided, only the `rmd_files` are now selected in addition to the `rmd_subdir` content. (thanks, @Gnossos, @cderv, #885).
+
 # CHANGES IN bookdown VERSION 0.18
 
 ## NEW FEATURES

--- a/R/utils.R
+++ b/R/utils.R
@@ -66,8 +66,10 @@ source_files = function(format = NULL, config = load_config(), all = FALSE) {
   subdir_files = setdiff(
     list.files(
       if (is.character(subdir)) subdir else '.', '[.]Rmd$', ignore.case = TRUE,
-      recursive = subdir_yes, full.names = is.character(subdir)),
-    files)
+      recursive = subdir_yes, full.names = is.character(subdir)
+    ),
+    files
+  )
   files = c(files, subdir_files)
   # keep only some wanted files
   if (length(files2 <- config[['rmd_files']]) > 0) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -62,13 +62,15 @@ source_files = function(format = NULL, config = load_config(), all = FALSE) {
   # a list of Rmd chapters
   subdir = config[['rmd_subdir']]; subdir_yes = isTRUE(subdir) || is.character(subdir)
   files = list.files('.', '[.]Rmd$', ignore.case = TRUE)
-  files = c(files, list.files(
-    if (is.character(subdir)) subdir else '.', '[.]Rmd$', ignore.case = TRUE,
-    recursive = subdir_yes, full.names = subdir_yes
-  ))
+  subdir_files = setdiff(
+    list.files(
+      if (is.character(subdir)) subdir else '.', '[.]Rmd$', ignore.case = TRUE,
+      recursive = subdir_yes, full.names = is.character(subdir)),
+    files)
+  files = c(files, subdir_files)
   if (length(files2 <- config[['rmd_files']]) > 0) {
     if (is.list(files2)) files2 = if (all) unlist(files2) else files2[[format]]
-    files = if (subdir_yes) c(files2, files) else files2
+    files = if (subdir_yes) c(files2, subdir_files) else files2
   } else {
     files = files[grep('^[^_]', basename(files))]  # exclude those start with _
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -74,9 +74,8 @@ source_files = function(format = NULL, config = load_config(), all = FALSE) {
     if (is.list(files2)) files2 = if (all) unlist(files2) else files2[[format]]
     # add those files to subdir content if any
     files = if (subdir_yes) c(files2, subdir_files) else files2
-  } else {
-    files = files[grep('^[^_]', basename(files))]  # exclude those start with _
   }
+  files = files[grep('^[^_]', basename(files))]  # exclude those start with _
   files = unique(gsub('^[.]/', '', files))
   index = 'index' == with_ext(files, '')
   # if there is a index.Rmd, put it in the beginning

--- a/R/utils.R
+++ b/R/utils.R
@@ -71,7 +71,7 @@ source_files = function(format = NULL, config = load_config(), all = FALSE) {
     files
   )
   files = c(files, subdir_files)
-  # keep only some wanted files
+  # if rmd_files is provided, use those files in addition to those under rmd_subdir
   if (length(files2 <- config[['rmd_files']]) > 0) {
     if (is.list(files2)) files2 = if (all) unlist(files2) else files2[[format]]
     # add those files to subdir content if any

--- a/R/utils.R
+++ b/R/utils.R
@@ -59,17 +59,20 @@ book_filename = function(config = load_config(), fallback = TRUE) {
 }
 
 source_files = function(format = NULL, config = load_config(), all = FALSE) {
-  # a list of Rmd chapters
   subdir = config[['rmd_subdir']]; subdir_yes = isTRUE(subdir) || is.character(subdir)
+  # a list of Rmd chapters
   files = list.files('.', '[.]Rmd$', ignore.case = TRUE)
+  # content in subdir if asked
   subdir_files = setdiff(
     list.files(
       if (is.character(subdir)) subdir else '.', '[.]Rmd$', ignore.case = TRUE,
       recursive = subdir_yes, full.names = is.character(subdir)),
     files)
   files = c(files, subdir_files)
+  # keep only some wanted files
   if (length(files2 <- config[['rmd_files']]) > 0) {
     if (is.list(files2)) files2 = if (all) unlist(files2) else files2[[format]]
+    # add those files to subdir content if any
     files = if (subdir_yes) c(files2, subdir_files) else files2
   } else {
     files = files[grep('^[^_]', basename(files))]  # exclude those start with _

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -115,12 +115,12 @@ assert('source_files() handles several configurations correcly', {
                 config = list(rmd_subdir = TRUE,
                               rmd_files = "01-first.Rmd"),
                 all = FALSE) %==%
-      c("01-first.Rmd", "subdir/_ignore.Rmd", "subdir/other.Rmd", "subdir2/last.Rmd"))
+      c("01-first.Rmd", "subdir/other.Rmd", "subdir2/last.Rmd"))
   (source_files(format = NULL,
                 config = list(rmd_subdir = c("subdir", "subdir2"),
                               rmd_files = "01-first.Rmd"),
                 all = FALSE) %==%
-      c("01-first.Rmd", "subdir/_ignore.Rmd", "subdir/other.Rmd", "subdir2/last.Rmd"))
+      c("01-first.Rmd", "subdir/other.Rmd", "subdir2/last.Rmd"))
   # clean tests
   unlink(project, recursive = TRUE); rm(project)
   setwd(old); rm(old)

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -70,10 +70,9 @@ assert('correctly clean empty dir if required', {
 assert('source_files() handles several configurations correcly', {
   # create dummy projet
   dir.create(project <- tempfile())
-  old <- setwd(project)
+  old = setwd(project)
   file.create(c("index.Rmd", "_ignored.Rmd", "01-first.Rmd"))
-  dir.create("subdir")
-  dir.create("subdir2")
+  dir.create("subdir"); dir.create("subdir2")
   file.create(c("subdir/other.Rmd", "subdir2/last.Rmd"))
   # default behavior is all in root dir except _*.Rmd
   (source_files(format = NULL, config = list(), all = FALSE) %==%

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -73,7 +73,7 @@ assert('source_files() handles several configurations correcly', {
   old = setwd(project)
   file.create(c("index.Rmd", "_ignored.Rmd", "01-first.Rmd"))
   dir.create("subdir"); dir.create("subdir2")
-  file.create(c("subdir/other.Rmd", "subdir2/last.Rmd"))
+  file.create(c("subdir/other.Rmd", "subdir/_ignore.Rmd", "subdir2/last.Rmd"))
   # default behavior is all in root dir except _*.Rmd
   (source_files(format = NULL, config = list(), all = FALSE) %==%
     c("index.Rmd", "01-first.Rmd"))
@@ -105,21 +105,22 @@ assert('source_files() handles several configurations correcly', {
                 all = FALSE) %==%
       c("index.Rmd", "01-first.Rmd", "subdir/other.Rmd", "subdir2/last.Rmd"))
   # using rmd_files with subdir adds to subdir content
+  # _*.Rmd are no more ignored in subdirectories
   (source_files(format = NULL,
-                config = list(rmd_subdir = "subdir",
+                config = list(rmd_subdir = "subdir2",
                               rmd_files = "01-first.Rmd"),
                 all = FALSE) %==%
-      c("01-first.Rmd", "subdir/other.Rmd"))
+      c("01-first.Rmd", "subdir2/last.Rmd"))
   (source_files(format = NULL,
                 config = list(rmd_subdir = TRUE,
                               rmd_files = "01-first.Rmd"),
                 all = FALSE) %==%
-      c("01-first.Rmd", "subdir/other.Rmd", "subdir2/last.Rmd"))
+      c("01-first.Rmd", "subdir/_ignore.Rmd", "subdir/other.Rmd", "subdir2/last.Rmd"))
   (source_files(format = NULL,
                 config = list(rmd_subdir = c("subdir", "subdir2"),
                               rmd_files = "01-first.Rmd"),
                 all = FALSE) %==%
-      c("01-first.Rmd", "subdir/other.Rmd", "subdir2/last.Rmd"))
+      c("01-first.Rmd", "subdir/_ignore.Rmd", "subdir/other.Rmd", "subdir2/last.Rmd"))
   # clean tests
   unlink(project, recursive = TRUE); rm(project)
   setwd(old); rm(old)

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -68,60 +68,45 @@ assert('correctly clean empty dir if required', {
 })
 
 assert('source_files() handles several configurations correcly', {
+  get_files = function(files = NULL, dirs = NULL, ...) {
+    source_files(config = list(rmd_files = files, rmd_subdir = dirs), ...)
+  }
+
   # create dummy projet
   dir.create(project <- tempfile())
   old = setwd(project)
-  file.create(c("index.Rmd", "_ignored.Rmd", "01-first.Rmd"))
-  dir.create("subdir"); dir.create("subdir2")
-  file.create(c("subdir/other.Rmd", "subdir/_ignore.Rmd", "subdir2/last.Rmd"))
+  files = c(
+    'index.Rmd', '_ignored.Rmd', '01-first.Rmd',
+    c('subdir/other.Rmd', 'subdir/_ignore.Rmd', 'subdir2/last.Rmd')
+  )
+  lapply(unique(dirname(files)), dir.create, FALSE, recursive = TRUE)
+  file.create(files)
+
   # default behavior is all in root dir except _*.Rmd
-  (source_files(format = NULL, config = list(), all = FALSE) %==%
-    c("index.Rmd", "01-first.Rmd"))
-  # using rmd_files allow to change default
-  (source_files(format = NULL,
-                config = list(rmd_files = "index.Rmd"),
-                all = FALSE) %==%
-    c("index.Rmd"))
-  (source_files(format = NULL,
-                config = list(rmd_files = c("index.Rmd", "_ignored.Rmd")),
-                all = FALSE) %==%
-    c("index.Rmd"))
+  (get_files() %==% files[c(1, 3)])
+
+  # using rmd_files allow to change default (_*.Rmd is always ignored, and
+  # index.Rmd is always the first)
+  (get_files(files[1]) %==% files[1])
+  (get_files(files[1:2]) %==% files[1])
+  (get_files(files[3:1]) %==% files[c(1, 3)])
+
   # format allows to filter selected files
-  (source_files(format = 'html',
-                config = list(rmd_files = list(html = "index.Rmd")),
-                all = FALSE) %==%
-    c("index.Rmd"))
+  (get_files(list(html = 'index.Rmd'), NULL, 'html') %==% files[1])
+
   # rmd_subdir allows subdir contents and root Rmds
-  (source_files(format = NULL,
-                config = list(rmd_subdir = TRUE),
-                all = FALSE) %==%
-    c("index.Rmd", "01-first.Rmd", "subdir/other.Rmd", "subdir2/last.Rmd"))
-  (source_files(format = NULL,
-                config = list(rmd_subdir = "subdir"),
-                all = FALSE) %==%
-    c("index.Rmd", "01-first.Rmd", "subdir/other.Rmd"))
-  (source_files(format = NULL,
-                config = list(rmd_subdir = c("subdir", "subdir2")),
-                all = FALSE) %==%
-      c("index.Rmd", "01-first.Rmd", "subdir/other.Rmd", "subdir2/last.Rmd"))
+  (get_files(, TRUE) %==% files[c(1, 3, 4, 6)])
+  (get_files(, dirname(files[4])) %==% files[c(1, 3, 4)])
+  (get_files(, dirname(files[c(4, 6)])) %==% files[c(1, 3, 4, 6)])
+
   # using rmd_files with subdir adds to subdir content
-  # _*.Rmd are no more ignored in subdirectories
-  (source_files(format = NULL,
-                config = list(rmd_subdir = "subdir2",
-                              rmd_files = "01-first.Rmd"),
-                all = FALSE) %==%
-      c("01-first.Rmd", "subdir2/last.Rmd"))
-  (source_files(format = NULL,
-                config = list(rmd_subdir = TRUE,
-                              rmd_files = "01-first.Rmd"),
-                all = FALSE) %==%
-      c("01-first.Rmd", "subdir/other.Rmd", "subdir2/last.Rmd"))
-  (source_files(format = NULL,
-                config = list(rmd_subdir = c("subdir", "subdir2"),
-                              rmd_files = "01-first.Rmd"),
-                all = FALSE) %==%
-      c("01-first.Rmd", "subdir/other.Rmd", "subdir2/last.Rmd"))
+  (get_files(files[3], dirname(files[6])) %==% files[c(3, 6)])
+  (get_files(files[3], TRUE) %==% files[c(3, 4, 6)])
+  (get_files(files[3], dirname(files[c(4, 6)])) %==% files[c(3, 4, 6)])
+
   # clean tests
   unlink(project, recursive = TRUE); rm(project)
   setwd(old); rm(old)
+
+  TRUE
 })

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -85,7 +85,7 @@ assert('source_files() handles several configurations correcly', {
   (source_files(format = NULL,
                 config = list(rmd_files = c("index.Rmd", "_ignored.Rmd")),
                 all = FALSE) %==%
-    c("index.Rmd", "_ignored.Rmd"))
+    c("index.Rmd"))
   # format allows to filter selected files
   (source_files(format = 'html',
                 config = list(rmd_files = list(html = "index.Rmd")),

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -83,6 +83,10 @@ assert('source_files() handles several configurations correcly', {
                 config = list(rmd_files = "index.Rmd"),
                 all = FALSE) %==%
     c("index.Rmd"))
+  (source_files(format = NULL,
+                config = list(rmd_files = c("index.Rmd", "_ignored.Rmd")),
+                all = FALSE) %==%
+    c("index.Rmd", "_ignored.Rmd"))
   # format allows to filter selected files
   (source_files(format = 'html',
                 config = list(rmd_files = list(html = "index.Rmd")),
@@ -97,6 +101,10 @@ assert('source_files() handles several configurations correcly', {
                 config = list(rmd_subdir = "subdir"),
                 all = FALSE) %==%
     c("index.Rmd", "01-first.Rmd", "subdir/other.Rmd"))
+  (source_files(format = NULL,
+                config = list(rmd_subdir = c("subdir", "subdir2")),
+                all = FALSE) %==%
+      c("index.Rmd", "01-first.Rmd", "subdir/other.Rmd", "subdir2/last.Rmd"))
   # using rmd_files with subdir adds to subdir content
   (source_files(format = NULL,
                 config = list(rmd_subdir = "subdir",
@@ -105,6 +113,11 @@ assert('source_files() handles several configurations correcly', {
       c("01-first.Rmd", "subdir/other.Rmd"))
   (source_files(format = NULL,
                 config = list(rmd_subdir = TRUE,
+                              rmd_files = "01-first.Rmd"),
+                all = FALSE) %==%
+      c("01-first.Rmd", "subdir/other.Rmd", "subdir2/last.Rmd"))
+  (source_files(format = NULL,
+                config = list(rmd_subdir = c("subdir", "subdir2"),
                               rmd_files = "01-first.Rmd"),
                 all = FALSE) %==%
       c("01-first.Rmd", "subdir/other.Rmd", "subdir2/last.Rmd"))


### PR DESCRIPTION
This fixes #885 and follows a series of features addition for `source_files` (#561, #601) in the past. 

There was still an issue when `rmd_files` is provided with `rmd_subdir` due to the following behavior: 
when `rmd_subdir` was provided, all the files from root dir and subdirs were selected. `rmd_files` was not able to filter out the desired root files. 

This PR will identify subdir files apart from root files if `rmd_subdir` is provided, then if `rmd_files` is provided also, it will concatenate `rmd_files` with `rmd_subdir` content only, discarding any other root files content. 

This PR also add tests so that all the desired behavior are checked: 
* by default, only root files are selected apart from ignored files (starting with `_`)
* `rmd_files` allows to select the root files and change default behavior
* `rmd_subdir` allows to add some subdirs content - by default root files 
* `rmd_subdir = TRUE` will get all the subdirs Rmd content. 
* if `rmd_files` is not provided, the files starting with an underscore in subdirectories will also be ignored.
* `rmd_files` allows to select the root files selected, in addition to `rmd_subdir`, adding those with the subdir content.

However, in this last case, there is one behavior which is currently happening and not sure it is desired: if `rmd_files` AND `rmd_subdir` are provided, the files starting with `_` inside sub directories will not be ignored anymore.  **Is this the desired behavior?**

I wonder if
* `_*.Rmd` files should be always ignored in bookdown. Would be a change in default, but you just need to remove the `_` and use `rmd_files` if you want to include it in some cases
* if it should be ignored by default in subdir content in all case. 

What do you think ? 
