### PR TITLE
Minor fix for bookdown::gitbook

### DIFF
--- a/inst/resources/gitbook/js/plugin-bookdown.js
+++ b/inst/resources/gitbook/js/plugin-bookdown.js
@@ -147,7 +147,7 @@ gitbook.require(["gitbook", "lodash", "jQuery"], function(gitbook, _, $) {
     if (typeof pos !== 'undefined') summary.scrollTop(pos);
 
     // highlight the TOC item that has same text as the heading in view as scrolling
-    if (toc && toc.scroll_highlight !== false) (function() {
+    if (toc && toc.scroll_highlight !== false && li.length > 0) (function() {
       // scroll the current TOC item into viewport
       var ht = $(window).height(), rect = li[0].getBoundingClientRect();
       if (rect.top >= ht || rect.top <= 0 || rect.bottom <= 0) {


### PR DESCRIPTION
In this Stackoverflow question, a minimal `bookdown::gitbook` document is created:  https://stackoverflow.com/q/62489019/2554330.  When viewing the result of the document in RStudio's previewer, I see this in the Javascript console:

```
Uncaught TypeError: Cannot read property 'getBoundingClientRect' of undefined
    at plugin-bookdown.js:152
    at Object.<anonymous> (plugin-bookdown.js:191)
    at Object.dispatch (jquery.min.js:3)
    at Object.r.handle (jquery.min.js:3)
    at Object.trigger (jquery.min.js:4)
    at Object.<anonymous> (jquery.min.js:4)
    at Function.each (jquery.min.js:2)
    at n.fn.init.each (jquery.min.js:2)
    at n.fn.init.trigger (jquery.min.js:4)
    at Object.start (app.min.js:1)
```

This happens because in that minimal document, `li[0]` is undefined.  The PR puts in a sanity check.  (There's a test for the length of `li` earlier in the code at line 105, but the change it makes in case of zero length, `li = chaps.first();`, doesn't solve the issue in the SO example.)