### PR TITLE
Enable pandoc `--file-scope` only when duplicate footnotes are detected

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # CHANGES IN bookdown VERSION 0.21
 
-
+- By default, the `--file-scope` argument is now only passed to pandoc when duplicate footnotes are detected in the manuscript. This is controlled by the `bookdown.render.file_scope` option, which now defaults to `"auto"`. Set the option to `TRUE` or `FALSE` to force a particular behavior irrespective of whether duplicates are detected.
 
 # CHANGES IN bookdown VERSION 0.20
 

--- a/R/ebook.R
+++ b/R/ebook.R
@@ -15,6 +15,7 @@
 #' @param epub_version Whether to use version 3 or 2 of EPUB.
 #' @param md_extensions A character string of Pandoc Markdown extensions.
 #' @param pandoc_args A vector of additional Pandoc arguments.
+#' @param file_scope Use pandoc \code{--file-scope} option when rendering.
 #' @param template Pandoc template to use for rendering. Pass \code{"default"}
 #'   to use Pandoc's built-in template; pass a path to use a custom template.
 #'   The default pandoc template should be sufficient for most use cases. In
@@ -29,7 +30,7 @@ epub_book = function(
   number_sections = TRUE, toc = FALSE, toc_depth = 3, stylesheet = NULL,
   cover_image = NULL, metadata = NULL, chapter_level = 1,
   epub_version = c('epub3', 'epub'), md_extensions = NULL, pandoc_args = NULL,
-  template = 'default'
+  file_scope = TRUE, template = 'default'
 ) {
   epub_version = match.arg(epub_version)
   args = c(
@@ -61,7 +62,7 @@ epub_book = function(
       move_output(output)
     }
   )
-  config = common_format_config(config, 'epub')
+  config = common_format_config(config, 'epub', file_scope = file_scope)
   config
 }
 

--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -23,7 +23,7 @@ gitbook = function(
   fig_caption = TRUE, number_sections = TRUE, self_contained = FALSE,
   lib_dir = 'libs', pandoc_args = NULL, ..., template = 'default',
   split_by = c('chapter', 'chapter+number', 'section', 'section+number', 'rmd', 'none'),
-  split_bib = TRUE, config = list(), table_css = TRUE
+  split_bib = TRUE, config = list(), table_css = TRUE, file_scope = TRUE
 ) {
   html_document2 = function(..., extra_dependencies = list()) {
     rmarkdown::html_document(
@@ -59,7 +59,7 @@ gitbook = function(
     move_files_html(output2, lib_dir)
     output2
   }
-  config = common_format_config(config, 'html')
+  config = common_format_config(config, 'html', file_scope = file_scope)
   config
 }
 

--- a/R/html.R
+++ b/R/html.R
@@ -29,6 +29,7 @@
 #' @param page_builder A function to combine different parts of a chapter into a
 #'   page (an HTML character vector). See \code{\link{build_chapter}} for the
 #'   specification of this function.
+#' @param file_scope Use pandoc \code{--file-scope} option when rendering.
 #' @note These functions are expected to be used in conjunction with
 #'   \code{\link{render_book}()}. It is almost meaningless if they are used with
 #'   \code{rmarkdown::render()}. Functions like \code{\link{html_document2}} are
@@ -52,7 +53,8 @@ html_chapters = function(
   toc = TRUE, number_sections = TRUE, fig_caption = TRUE, lib_dir = 'libs',
   template = bookdown_file('templates/default.html'), pandoc_args = NULL, ...,
   base_format = rmarkdown::html_document, split_bib = TRUE, page_builder = build_chapter,
-  split_by = c('section+number', 'section', 'chapter+number', 'chapter', 'rmd', 'none')
+  split_by = c('section+number', 'section', 'chapter+number', 'chapter', 'rmd', 'none'),
+  file_scope = TRUE
 ) {
   config = get_base_format(base_format, list(
     toc = toc, number_sections = number_sections, fig_caption = fig_caption,
@@ -69,7 +71,7 @@ html_chapters = function(
     move_files_html(output2, lib_dir)
     output2
   }
-  config = common_format_config(config, 'html')
+  config = common_format_config(config, 'html', file_scope = file_scope)
   config
 }
 

--- a/R/latex.R
+++ b/R/latex.R
@@ -29,12 +29,14 @@
 #'   \code{NULL}, the quote footer will not be processed.
 #' @param highlight_bw Whether to convert colors for syntax highlighting to
 #'   black-and-white (grayscale).
+#' @param file_scope Use pandoc \code{--file-scope} option when rendering.
 #' @note This output format can only be used with \code{\link{render_book}()}.
 #' @export
 pdf_book = function(
   toc = TRUE, number_sections = TRUE, fig_caption = TRUE, pandoc_args = NULL, ...,
   base_format = rmarkdown::pdf_document, toc_unnumbered = TRUE,
-  toc_appendix = FALSE, toc_bib = FALSE, quote_footer = NULL, highlight_bw = FALSE
+  toc_appendix = FALSE, toc_bib = FALSE, quote_footer = NULL, highlight_bw = FALSE,
+  file_scope = TRUE
 ) {
   config = get_base_format(base_format, list(
     toc = toc, number_sections = number_sections, fig_caption = fig_caption,
@@ -86,7 +88,7 @@ pdf_book = function(
       if (rmarkdown::pandoc_available('2.7.1')) '-Mhas-frontmatter=false'
     )
   }
-  config = common_format_config(config, 'latex')
+  config = common_format_config(config, 'latex', file_scope = file_scope)
   config
 }
 

--- a/R/render.R
+++ b/R/render.R
@@ -148,7 +148,9 @@ render_cur_session = function(files, main, config, output_format, clean, envir, 
     insert_chapter_script(config, 'before'),
     insert_chapter_script(config, 'after')
   )
-  rmarkdown::render(main, output_format, ..., clean = clean, envir = envir)
+
+  rmarkdown::render(main, output_format, ..., clean = clean, envir = envir,
+                    output_options = render_output_options(main))
 }
 
 render_new_session = function(files, main, config, output_format, clean, envir, ...) {
@@ -191,9 +193,23 @@ render_new_session = function(files, main, config, output_format, clean, envir, 
 
   rmarkdown::render(
     main, output_format, ..., clean = clean, envir = envir,
+    output_options = render_output_options(main),
     run_pandoc = TRUE, knit_meta = knit_meta
   )
 
+}
+
+render_output_options <- function(main) {
+  output_options = list()
+  file_scope = getOption('bookdown.render.file_scope', "auto")
+  if (isTRUE(file_scope)) {
+    output_options$file_scope = TRUE
+  } else if (file_scope == "auto") {
+    output_options$file_scope = has_duplicate_footnotes(main)
+  } else {
+    output_options$file_scope = FALSE
+  }
+  output_options
 }
 
 #' Clean up the output files and directories from the book

--- a/R/utils.R
+++ b/R/utils.R
@@ -25,11 +25,9 @@ new_counters = function(type, rownames) {
 }
 
 # set common format config
-common_format_config = function(
-  config, format, file_scope = getOption('bookdown.render.file_scope', TRUE)
-) {
+common_format_config = function(config, format, file_scope) {
 
-  # provide file_scope unless disabled via the global option
+  # provide file_scope if requested
   if (file_scope) config$file_scope = md_chapter_splitter
 
   # set output format
@@ -536,3 +534,10 @@ strip_latex_body = function(x, alt = '\nThe content was intentionally removed.\n
   }
   c(x1, x2[sort(i)], '\\end{document}')
 }
+
+has_duplicate_footnotes <- function(input) {
+  args <- c(input, "--to", "json")
+  result <- system2(rmarkdown::pandoc_exec(), args, stdout = TRUE, stderr = TRUE)
+  any(grepl("[WARNING] Duplicate note", result, fixed = TRUE))
+}
+

--- a/R/word.R
+++ b/R/word.R
@@ -2,7 +2,7 @@
 #' @export
 markdown_document2 = function(
   fig_caption = TRUE, md_extensions = NULL, pandoc_args = NULL, ...,
-  base_format = rmarkdown::md_document
+  file_scope = TRUE, base_format = rmarkdown::md_document
 ) {
   from = rmarkdown::from_rmarkdown(fig_caption, md_extensions)
 
@@ -21,7 +21,7 @@ markdown_document2 = function(
     if (is.function(post)) output = post(metadata, input, output, clean, verbose)
     move_output(output)
   }
-  config = common_format_config(config, config$pandoc$to)
+  config = common_format_config(config, config$pandoc$to, file_scope = file_scope)
   config
 }
 

--- a/man/epub_book.Rd
+++ b/man/epub_book.Rd
@@ -19,6 +19,7 @@ epub_book(
   epub_version = c("epub3", "epub"),
   md_extensions = NULL,
   pandoc_args = NULL,
+  file_scope = TRUE,
   template = "default"
 )
 }
@@ -45,6 +46,8 @@ applied to the eBook.}
 \item{md_extensions}{A character string of Pandoc Markdown extensions.}
 
 \item{pandoc_args}{A vector of additional Pandoc arguments.}
+
+\item{file_scope}{Use pandoc \code{--file-scope} option when rendering.}
 
 \item{template}{Pandoc template to use for rendering. Pass \code{"default"}
 to use Pandoc's built-in template; pass a path to use a custom template.

--- a/man/gitbook.Rd
+++ b/man/gitbook.Rd
@@ -15,7 +15,8 @@ gitbook(
   split_by = c("chapter", "chapter+number", "section", "section+number", "rmd", "none"),
   split_bib = TRUE,
   config = list(),
-  table_css = TRUE
+  table_css = TRUE,
+  file_scope = TRUE
 )
 }
 \arguments{
@@ -56,6 +57,8 @@ the font/theme settings.}
 \item{table_css}{\code{TRUE} to load gitbook's default CSS for tables. Choose
 \code{FALSE} to unload and use customized CSS (for exmaple, bootstrap) via
 the \code{css} option. Default is \code{TRUE}.}
+
+\item{file_scope}{Use pandoc \code{--file-scope} option when rendering.}
 }
 \description{
 This output format function ported a style provided by GitBook

--- a/man/html_chapters.Rd
+++ b/man/html_chapters.Rd
@@ -17,7 +17,8 @@ html_chapters(
   base_format = rmarkdown::html_document,
   split_bib = TRUE,
   page_builder = build_chapter,
-  split_by = c("section+number", "section", "chapter+number", "chapter", "rmd", "none")
+  split_by = c("section+number", "section", "chapter+number", "chapter", "rmd", "none"),
+  file_scope = TRUE
 )
 
 html_book(...)
@@ -55,6 +56,8 @@ Introduction} will be \file{introduction.html}; for \code{chapter+number}
 and \code{section+number}, the chapter/section numbers will be prepended to
 the HTML filenames, e.g. \file{1-introduction.html} and
 \file{2-1-literature.html}.}
+
+\item{file_scope}{Use pandoc \code{--file-scope} option when rendering.}
 }
 \value{
 An R Markdown output format object to be passed to

--- a/man/html_document2.Rd
+++ b/man/html_document2.Rd
@@ -54,6 +54,7 @@ markdown_document2(
   md_extensions = NULL,
   pandoc_args = NULL,
   ...,
+  file_scope = TRUE,
   base_format = rmarkdown::md_document
 )
 
@@ -83,6 +84,8 @@ sequentially in the document from 1, 2, ..., and you cannot cross-reference
 section headers in this case.}
 
 \item{base_format}{An output format function to be used as the base format.}
+
+\item{file_scope}{Use pandoc \code{--file-scope} option when rendering.}
 }
 \value{
 An R Markdown output format object to be passed to

--- a/man/pdf_book.Rd
+++ b/man/pdf_book.Rd
@@ -15,7 +15,8 @@ pdf_book(
   toc_appendix = FALSE,
   toc_bib = FALSE,
   quote_footer = NULL,
-  highlight_bw = FALSE
+  highlight_bw = FALSE,
+  file_scope = TRUE
 )
 }
 \arguments{
@@ -42,6 +43,8 @@ prepended to the footer, and \code{quote_footer[2]} will be appended; if
 
 \item{highlight_bw}{Whether to convert colors for syntax highlighting to
 black-and-white (grayscale).}
+
+\item{file_scope}{Use pandoc \code{--file-scope} option when rendering.}
 }
 \description{
 Convert R Markdown files to PDF after resolving the special tokens of


### PR DESCRIPTION
By default, the `--file-scope` argument is now only passed to pandoc when duplicate footnotes are detected in the manuscript. This is controlled by the `bookdown.render.file_scope` option, which now defaults to `"auto"`. Set the option to `TRUE` or `FALSE` to force a particular behavior irrespective of whether duplicates are detected.

Addresses https://github.com/rstudio/bookdown/issues/909