### PR TITLE
pass file_scope to rmarkdown only when duplicate footnotes are detected

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bookdown
 Type: Package
 Title: Authoring Books and Technical Documents with R Markdown
-Version: 0.20.1
+Version: 0.20.2
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("JJ", "Allaire", role = "ctb"),
@@ -61,7 +61,7 @@ License: GPL-3
 Imports:
     htmltools (>= 0.3.6),
     knitr (>= 1.22),
-    rmarkdown (>= 2.3),
+    rmarkdown (>= 2.3.3),
     xfun (>= 0.6),
     tinytex (>= 0.12)
 Suggests:
@@ -74,6 +74,8 @@ Suggests:
     testit (>= 0.9),
     tufte,
     webshot
+Remotes:
+    rstudio/rmarkdown@file-scope-param
 URL: https://github.com/rstudio/bookdown
 BugReports: https://github.com/rstudio/bookdown/issues
 SystemRequirements: Pandoc (>= 1.17.2)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # CHANGES IN bookdown VERSION 0.21
 
-
+- By default, the `--file-scope` argument is now only passed to pandoc when duplicate footnotes are detected in the manuscript. This is controlled by the `bookdown.render.file_scope` option, which now defaults to `"auto"`. Set the option to `TRUE` or `FALSE` to force a particular behavior irrespective of whether duplicates are detected.
 
 # CHANGES IN bookdown VERSION 0.20
 

--- a/R/html.R
+++ b/R/html.R
@@ -138,7 +138,7 @@ html_document2 = function(
     write_utf8(x, output)
     output
   }
-  config = common_format_config(config, 'html', file_scope = FALSE)
+  config = common_format_config(config, 'html')
   config
 }
 

--- a/R/render.R
+++ b/R/render.R
@@ -148,7 +148,8 @@ render_cur_session = function(files, main, config, output_format, clean, envir, 
     insert_chapter_script(config, 'before'),
     insert_chapter_script(config, 'after')
   )
-  rmarkdown::render(main, output_format, ..., clean = clean, envir = envir)
+  rmarkdown::render(main, output_format, ..., clean = clean, envir = envir,
+                    file_scope = render_file_scope(main))
 }
 
 render_new_session = function(files, main, config, output_format, clean, envir, ...) {
@@ -191,9 +192,21 @@ render_new_session = function(files, main, config, output_format, clean, envir, 
 
   rmarkdown::render(
     main, output_format, ..., clean = clean, envir = envir,
-    run_pandoc = TRUE, knit_meta = knit_meta
+    run_pandoc = TRUE, knit_meta = knit_meta,
+    file_scope = render_file_scope(main),
   )
 
+}
+
+render_file_scope <- function(main) {
+  file_scope = getOption('bookdown.render.file_scope', "auto")
+  if (isTRUE(file_scope)) {
+    md_chapter_splitter
+  } else if (file_scope == "auto" && has_duplicate_footnotes(main)) {
+    md_chapter_splitter
+  } else {
+    NULL
+  }
 }
 
 #' Clean up the output files and directories from the book

--- a/R/utils.R
+++ b/R/utils.R
@@ -25,12 +25,7 @@ new_counters = function(type, rownames) {
 }
 
 # set common format config
-common_format_config = function(
-  config, format, file_scope = getOption('bookdown.render.file_scope', TRUE)
-) {
-
-  # provide file_scope unless disabled via the global option
-  if (file_scope) config$file_scope = md_chapter_splitter
+common_format_config = function(config, format) {
 
   # set output format
   config$bookdown_output_format = format
@@ -536,3 +531,10 @@ strip_latex_body = function(x, alt = '\nThe content was intentionally removed.\n
   }
   c(x1, x2[sort(i)], '\\end{document}')
 }
+
+has_duplicate_footnotes = function(input) {
+  args = c(rmarkdown::pandoc_path_arg(input), "--to", "json")
+  result = rmarkdown::pandoc_run(args, stdout = TRUE, stderr = TRUE)
+  any(grepl("[WARNING] Duplicate note", result, fixed = TRUE))
+}
+


### PR DESCRIPTION
By default, the `--file-scope` argument is now only passed to pandoc when duplicate footnotes are detected in the manuscript. This is controlled by the `bookdown.render.file_scope` option, which now defaults to `"auto".` Set the option to `TRUE` or `FALSE` to force a particular behavior irrespective of whether duplicates are detected.

Addresses https://github.com/rstudio/bookdown/issues/909