### PR TITLE
Disable pandoc --file-scope by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # CHANGES IN bookdown VERSION 0.21
 
+## MINOR CHANGES
 
+- The `--file-scope` behavior introduced in bookdown v0.20 is now disabled by default. This is due to broken TOC links for duplicate section names (e.g. "Exercises") that have automatically generated identifiers.
 
 # CHANGES IN bookdown VERSION 0.20
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## MINOR CHANGES
 
-- The `--file-scope` behavior introduced in bookdown v0.20 is now disabled by default. This is due to broken TOC links for duplicate section names (e.g. "Exercises") that have automatically generated identifiers.
+- The `--file-scope` behavior introduced in bookdown v0.20 is now disabled by default. This is due to broken TOC links for duplicate section names (e.g., "Exercises"; see #909) that have automatically generated identifiers.
 
 # CHANGES IN bookdown VERSION 0.20
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -26,10 +26,10 @@ new_counters = function(type, rownames) {
 
 # set common format config
 common_format_config = function(
-  config, format, file_scope = getOption('bookdown.render.file_scope', TRUE)
+  config, format, file_scope = getOption('bookdown.render.file_scope', FALSE)
 ) {
 
-  # provide file_scope unless disabled via the global option
+  # provide file_scope if requested
   if (file_scope) config$file_scope = md_chapter_splitter
 
   # set output format


### PR DESCRIPTION
The `--file-scope` behavior introduced in bookdown v0.20 is now disabled by default. This is due to broken TOC links for duplicate section names (e.g. "Exercises") that have automatically generated identifiers.

Addresses https://github.com/rstudio/bookdown/issues/909