### PR TITLE
Tweak handling of mathjax argument in gitbook template

### DIFF
--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -21,7 +21,7 @@
 #' @export
 gitbook = function(
   fig_caption = TRUE, number_sections = TRUE, self_contained = FALSE,
-  lib_dir = 'libs', pandoc_args = NULL, ..., template = 'default',
+  lib_dir = 'libs', pandoc_args = NULL, ..., template = 'default', mathjax = "default",
   split_by = c('chapter', 'chapter+number', 'section', 'section+number', 'rmd', 'none'),
   split_bib = TRUE, config = list(), table_css = TRUE
 ) {
@@ -37,9 +37,33 @@ gitbook = function(
   config = html_document2(
     toc = TRUE, number_sections = number_sections, fig_caption = fig_caption,
     self_contained = self_contained, lib_dir = lib_dir, theme = NULL,
-    template = template, pandoc_args = pandoc_args2(pandoc_args), ...
+    template = template, pandoc_args = pandoc_args2(pandoc_args),
+    mathjax = mathjax, ...
   )
   split_by = match.arg(split_by)
+  pre = config$pre_processor # in case a pre processor have been defined
+  config$pre_processor = function(
+    metadata, input_file, runtime, knit_meta, files_dir, output_dir
+  ) {
+    if (is.function(pre))
+      args = pre(metadata, input_file, runtime, knit_meta, files_dir, output_dir)
+
+    # adjusting mathjax default handling by rmarkdown in pandoc_mathjax_args()
+    # if a custom url is passed
+    if (!is.null(mathjax) && !identical(mathjax, "default")) {
+      # if no mathjax arg, rmarkdown did not included it and it stays that way
+      if(length(i <- grep("--mathjax", args))) {
+        # if local url is inserted by rmarkdown
+        if (identical(mathjax, "local"))
+          mathjax = gsub("^--mathjax=(.*)$", "\\1", args[i])
+        # replacing the mathjax and setting a variable for the gitbook template
+        if (length(i)) args = args[-i]
+        args = c(args, "--mathjax",
+                 "--variable", paste0("mathjax-url:", mathjax))
+      }
+    }
+    args
+  }
   post = config$post_processor  # in case a post processor have been defined
   config$post_processor = function(metadata, input, output, clean, verbose) {
     if (is.function(post)) output = post(metadata, input, output, clean, verbose)
@@ -284,4 +308,8 @@ download_filenames = function(config) {
     }
   }
   if (length(downloads)) I(downloads)
+}
+
+gitbook_mathjax_arg <- function (mathjax, template, self_contained, files_dir, output_dir)
+{
 }

--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -3,7 +3,7 @@
 #' This output format function ported a style provided by GitBook
 #' (\url{https://www.gitbook.com}) for R Markdown.
 #' @inheritParams html_chapters
-#' @param fig_caption,number_sections,self_contained,lib_dir,pandoc_args ...
+#' @param fig_caption,number_sections,self_contained,lib_dir,pandoc_args,mathjax ...
 #'   Arguments to be passed to \code{rmarkdown::\link{html_document}()}
 #'   (\code{...} not including \code{toc}, and \code{theme}).
 #' @param template Pandoc template to use for rendering. Pass \code{"default"}

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -172,7 +172,7 @@ $if(math)$
   (function () {
     var script = document.createElement("script");
     script.type = "text/javascript";
-    var src = "$if(mathjax)$$mathjax$$endif$";
+    var src = "$if(mathjax)$$if(mathjax-url)$$mathjax-url$$else$$mathjax$$endif$$endif$";
     if (src === "" || src === "true") src = "https://mathjax.rstudio.com/latest/MathJax.js?config=TeX-MML-AM_CHTML";
     if (location.protocol !== "file:")
       if (/^https?:/.test(src))

--- a/man/gitbook.Rd
+++ b/man/gitbook.Rd
@@ -12,6 +12,7 @@ gitbook(
   pandoc_args = NULL,
   ...,
   template = "default",
+  mathjax = "default",
   split_by = c("chapter", "chapter+number", "section", "section+number", "rmd", "none"),
   split_bib = TRUE,
   config = list(),

--- a/man/gitbook.Rd
+++ b/man/gitbook.Rd
@@ -20,7 +20,7 @@ gitbook(
 )
 }
 \arguments{
-\item{fig_caption, number_sections, self_contained, lib_dir, pandoc_args}{...
+\item{fig_caption, number_sections, self_contained, lib_dir, pandoc_args, mathjax}{...
 Arguments to be passed to \code{rmarkdown::\link{html_document}()}
 (\code{...} not including \code{toc}, and \code{theme}).}
 


### PR DESCRIPTION
This could resolve #915 

It is only a suggestion for modificaiton in `bookdown` only. There are other solution to deal with that more broadly for all the formats: 

* tweak rmarkdown `pandoc_mathjax_args` in pre processor
* (maybe) Use a lua filter to change the Meta information if possible (just an idea for now)

But on this PR, here is what has changed based on the analysis in https://github.com/rstudio/bookdown/issues/915#issuecomment-680985781

``` r
# on the branch custom-mathjax from this PR
pkgload::load_all()
#> Loading bookdown

temp_file <- tempfile(fileext = ".Rmd")
xfun::write_utf8(c(
  "---",
  "title: Test",
  "---",
  "",
  "# test",
  "",
  "$1+1$"
), temp_file)

render_gitbook <- function(...) {
  # we insure pandoc 2.7.3 for now
  rmarkdown::find_pandoc(version = "2.7.3")
  res <- xfun::in_dir(tempdir(),
               rmarkdown::render(
                 temp_file, "bookdown::gitbook",
                 output_options = list(...),
                 quiet = TRUE)
  )
  html <- xfun::read_utf8(res)
  i <- grep("<!-- dynamically load mathjax for compatibility with self-contained -->",
       html)
  if (!length(i)) return("no Mathjax")
  start_s <- grep("<script>", html)
  end_s <- grep("</script>", html)
  xfun::raw_string(html[start_s[start_s > i][1]:end_s[end_s>i][1]])
}

custom_mathjax <- "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
```

This PR changes nothing at the fact gitbook and mathjax does not work when `self_contained = TRUE`

``` r
render_gitbook(self_contained = TRUE)
#> Warning: MathJax doesn't work with self_contained when not using the rmarkdown
#> "default" template.
#> [1] "no Mathjax"
render_gitbook(self_contained = TRUE, mathjax = custom_mathjax)
#> Warning: MathJax doesn't work with self_contained when not using the rmarkdown
#> "default" template.
#> [1] "no Mathjax"
```

Custom url now works. See the value of `src` below

``` r
render_gitbook(mathjax = custom_mathjax)
#> <script>
#>   (function () {
#>     var script = document.createElement("script");
#>     script.type = "text/javascript";
#>     var src = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js";
#>     if (src === "" || src === "true") src = "https://mathjax.rstudio.com/latest/MathJax.js?config=TeX-MML-AM_CHTML";
#>     if (location.protocol !== "file:")
#>       if (/^https?:/.test(src))
#>         src = src.replace(/^https?:/, '');
#>     script.src = src;
#>     document.getElementsByTagName("head")[0].appendChild(script);
#>   })();
#> </script>
```

it works also with mathjax local now. See `src` below

``` r
render_gitbook(mathjax = "local")
#> <script>
#>   (function () {
#>     var script = document.createElement("script");
#>     script.type = "text/javascript";
#>     var src = "libs/mathjax-local/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
#>     if (src === "" || src === "true") src = "https://mathjax.rstudio.com/latest/MathJax.js?config=TeX-MML-AM_CHTML";
#>     if (location.protocol !== "file:")
#>       if (/^https?:/.test(src))
#>         src = src.replace(/^https?:/, '');
#>     script.src = src;
#>     document.getElementsByTagName("head")[0].appendChild(script);
#>   })();
#> </script>
```

with no mathjax asked, it is still working - no mathjax is used.

``` r
render_gitbook(mathjax = NULL)
#> [1] "no Mathjax"
```

with custom template, we can decide to pass the `mathjax-url` variable for use in custom template

``` r
library(htmltools)
html_content <- div(
  # hack to work with previous function render_gitbook
  HTML("<!-- dynamically load mathjax for compatibility with self-contained -->"),
  tags$script(
    p("this is mathjax variable: $mathjax$"),
    br(),
    p("this is mathjaxurl variable: $mathjaxurl$"),
    br(),
    p("this is mathjax-url variable: $mathjax-url$"),
    br(),
    p("this is math variable: $math$")
  )
)
template <- tempfile(fileext = ".html")
xfun::write_utf8(as.character(html_content), template)
```

custom templates can use pandoc mathjax-url variable, that corresponds
but it is not used by pandoc - So I guess we should choice what should happen here.
- [ ] choose what to do when custom mathjax AND template are used

``` r
render_gitbook(mathjax = custom_mathjax, template = template)
#>   <script>
#>     <p>this is mathjax variable: true</p>
#>     <br/>
#>     <p>this is mathjaxurl variable: https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js</p>
#>     <br/>
#>     <p>this is mathjax-url variable: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js</p>
#>     <br/>
#>     <p>this is math variable: <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-AMS_CHTML-full" type="text/javascript"></script></p>
# same for mathjax = local
render_gitbook(mathjax = "local", template = template)
#>   <script>
#>     <p>this is mathjax variable: true</p>
#>     <br/>
#>     <p>this is mathjaxurl variable: https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js</p>
#>     <br/>
#>     <p>this is mathjax-url variable: libs/mathjax-local/MathJax.js?config=TeX-AMS-MML_HTMLorMML</p>
#>     <br/>
#>     <p>this is math variable: <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-AMS_CHTML-full" type="text/javascript"></script></p>
```

still does work with self\_contained = TRUE

``` r
render_gitbook(mathjax = custom_mathjax, template = template, self_contained= TRUE)
#> Warning: MathJax doesn't work with self_contained when not using the rmarkdown
#> "default" template.
#>   <script>
#>     <p>this is mathjax variable: </p>
#>     <br/>
#>     <p>this is mathjaxurl variable: </p>
#>     <br/>
#>     <p>this is mathjax-url variable: </p>
#>     <br/>
#>     <p>this is math variable: </p>
#>   </script>
```

with default, the pandoc mathjax default and custom template one are used.

``` r
render_gitbook(template = template)
#>   <script>
#>     <p>this is mathjax variable: true</p>
#>     <br/>
#>     <p>this is mathjaxurl variable: https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js</p>
#>     <br/>
#>     <p>this is mathjax-url variable: </p>
#>     <br/>
#>     <p>this is math variable: <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-AMS_CHTML-full" type="text/javascript"></script></p>
```

we see that with a custom template it does not change a lot

#### About other format

It seems `html_chapter` uses `default.html` that does use the `math` pandoc variable. I suppose because `self_contained` is forced to FALSE. 

This is one option for gitbook format too if we don't want to support self_contained gitbook with mathjax (as it is not working anyway for now it seems)

@yihui I am waiting on your thoughts on all that to see what we do