### PR TITLE
add number_sections argument to markdown_document2 (closes #756)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bookdown
 Type: Package
 Title: Authoring Books and Technical Documents with R Markdown
-Version: 0.20.5
+Version: 0.20.6
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("JJ", "Allaire", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,7 +61,7 @@ License: GPL-3
 Imports:
     htmltools (>= 0.3.6),
     knitr (>= 1.22),
-    rmarkdown (>= 2.3),
+    rmarkdown (>= 2.3.5),
     xfun (>= 0.13),
     tinytex (>= 0.12)
 Suggests:
@@ -80,3 +80,4 @@ SystemRequirements: Pandoc (>= 1.17.2)
 LazyData: TRUE
 RoxygenNote: 7.1.1
 Encoding: UTF-8
+Remotes: rstudio/rmarkdown

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 - Make sure `search_index.json` contains valid characters for the JSON format (thanks, @wlandau, #913).
 
+- Add the `number_sections` argument to `markdown_document2` and its family (thanks, @atusy, #756)
+
 ## MINOR CHANGES
 
 - The `--file-scope` behavior introduced in bookdown v0.20 is now disabled by default. This is due to broken TOC links for duplicate section names (e.g., "Exercises"; see #909) that have automatically generated identifiers.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # CHANGES IN bookdown VERSION 0.21
 
+## NEW FEATURES
+
+- Add the `number_sections` argument to `markdown_document2()` and its family. This allows to have now figure references numbered by chapters in these formats, like `word_document2()` or `odt_document2()` for example (thanks, @atusy, #756).
+
 ## BUG FIXES
 
 - Correctly encode the document title when creating the twitter sharing link from a bookdown chapter (thanks, @maelle, #934).
@@ -11,8 +15,6 @@
 - The `--file-scope` behavior introduced in bookdown v0.20 is now disabled by default. This is due to broken TOC links for duplicate section names (e.g., "Exercises"; see #909) that have automatically generated identifiers.
 
 - The `clean_envir` argument of `bookdown::render_book()` has been deprecated and will be removed in the future (thanks, @jenslaufer, #932).
-
-- Add the `number_sections` argument to `markdown_document2` and its family (thanks, @atusy, #756)
 
 # CHANGES IN bookdown VERSION 0.20
 

--- a/R/word.R
+++ b/R/word.R
@@ -1,19 +1,20 @@
 #' @rdname html_document2
 #' @export
 markdown_document2 = function(
-  fig_caption = TRUE, md_extensions = NULL, pandoc_args = NULL, ...,
-  base_format = rmarkdown::md_document
+  number_sections = TRUE, fig_caption = TRUE, md_extensions = NULL,
+  pandoc_args = NULL, ..., base_format = rmarkdown::md_document
 ) {
   from = rmarkdown::from_rmarkdown(fig_caption, md_extensions)
 
   config = get_base_format(base_format, list(
-    fig_caption = fig_caption, md_extensions = md_extensions, pandoc_args = pandoc_args, ...
+    number_sections = number_sections, fig_caption = fig_caption,
+    md_extensions = md_extensions, pandoc_args = pandoc_args, ...
   ))
   pre = config$pre_processor
   config$pre_processor = function(metadata, input_file, ...) {
     # Pandoc does not support numbered sections for Word, so figures/tables have
     # to be numbered globally from 1 to n
-    process_markdown(input_file, from, pandoc_args, TRUE)
+    process_markdown(input_file, from, pandoc_args, !number_sections)
     if (is.function(pre)) pre(metadata, input_file, ...)
   }
   post = config$post_processor

--- a/man/html_document2.Rd
+++ b/man/html_document2.Rd
@@ -50,6 +50,7 @@ tufte_handout2(...)
 tufte_book2(...)
 
 markdown_document2(
+  number_sections = TRUE,
   fig_caption = TRUE,
   md_extensions = NULL,
   pandoc_args = NULL,

--- a/tests/rmd/number-sections.Rmd
+++ b/tests/rmd/number-sections.Rmd
@@ -1,0 +1,27 @@
+---
+title: "A Book"
+author: "Frida Gomam"
+output: 
+  bookdown::markdown_document2:
+    number_sections: true
+---
+
+# Section 1
+
+Some content
+
+## subsection 1
+
+Hello.
+
+See chapter 2 now at \@ref(section-2)
+
+# Section 2
+
+## subsection 2 {#sub2}
+
+```{r iris-plot, fig.cap = "A plot"}
+plot(iris)
+```
+
+See figure \@ref(fig:iris-plot)

--- a/tests/test-rmd.R
+++ b/tests/test-rmd.R
@@ -46,4 +46,10 @@ if (Sys.getenv('NOT_CRAN') == 'true') local({
       !any(grepl('id="fn3"', readLines('rmd/subsection-footnotes-1.html')))) {
     stop('Failed to move the footnotes back to subsection 1 in parse_footnotes.Rmd')
   }
+
+  # number sections now works in markdown_document2
+  if (!any(readLines("rmd/number-sections.md") == "1.1 subsection 1") ||
+      !any(grepl("<a href=.*>2.1</a>", readLines("rmd/number-sections.md")))) {
+    stop("Something wrong in number_sections.Rmd")
+  }
 })


### PR DESCRIPTION
Please merge after https://github.com/rstudio/rmarkdown/pull/1879

This PR adds number_sections argument to `markdown_document2` and its family (e.g., `word_document2`).

I set `TRUE` as a default value to be consistent with other formats (e.g., `html_document2`).
However, this may not be a good idea in case users' Rmd files manually numbered sections...
