### PR TITLE
fix #834: preserve input Rmd's origin path in opts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 - The new syntax for theorem and proof environments introduced in **bookdown** requires Pandoc >= 2.3 instead of 2.0 (thanks, @markhymers, #979 #980).
 
+## MINOR CHANGES
+
+- `opts$get('input_rmd')` now stores original file path rather than basename, and when Rmd file under subdirectory changes, `serve_book()` will refresh correctly now (thanks, @shenfei, #834 #955).
+
 # CHANGES IN bookdown VERSION 0.21
 
 ## NEW FEATURES

--- a/R/render.R
+++ b/R/render.R
@@ -92,7 +92,7 @@ render_book = function(
   if (!preview) unlink(ref_keys_path(output_dir))  # clean up reference-keys.txt
   # store output directory and the initial input Rmd name
   opts$set(
-    output_dir = output_dir, input_rmd = basename(input), preview = preview
+    output_dir = output_dir, input_rmd = input, preview = preview
   )
 
   aux_diro = '_bookdown_files'


### PR DESCRIPTION
Remove input Rmd file's path in opts could bring inconsistency.
For example in `split_chapter()`, we compare `input_rmd` and `nms_chaps`
to determine if we could skip writing html. Then when we call
`serve_book()`, all the changed Rmd files under subdir will be ignored
due to the absence of `input_rmd`'s full path.
This is the root cause of #834.

Making this change at the `opts$set` part leaves us more freedom.
We can use `basename` to trim the path later if necessary.
On the other hand, it's not easy to recover the original path info.