### PR TITLE
Allow "url" to work with or without trailing /

### DIFF
--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="$pagetitle$" />
   <meta property="og:type" content="book" />
   $if(url)$<meta property="og:url" content="$url$" />$endif$
-  $if(cover-image)$<meta property="og:image" content="$url$$cover-image$" />$endif$
+  $if(cover-image)$<meta property="og:image" content="$url$/$cover-image$" />$endif$
   $if(description)$<meta property="og:description" content="$description$" />$endif$
   $if(github-repo)$<meta name="github-repo" content="$github-repo$" />$endif$
 
@@ -19,7 +19,7 @@
   <meta name="twitter:title" content="$pagetitle$" />
   $if(twitter-handle)$<meta name="twitter:site" content="@$twitter-handle$" />$endif$
   $if(description)$<meta name="twitter:description" content="$description$" />$endif$
-  $if(cover-image)$<meta name="twitter:image" content="$url$$cover-image$" />$endif$
+  $if(cover-image)$<meta name="twitter:image" content="$url$/$cover-image$" />$endif$
 
 $for(author-meta)$
 <meta name="author" content="$author-meta$" />


### PR DESCRIPTION
Adds the slash no matter what. If trailing slash is already there, the complete URI of the cover image will simply have an extra slash, which should be fine.