### PR TITLE
Fix pandoc version dependency for --metadata-file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CHANGES IN bookdown VERSION 0.22
 
+## BUG FIXES
+
+- The new syntax for theorem and proof environments introduced in **bookdown** requires Pandoc >= 2.3 instead of 2.0 (thanks, @markhymers, #979 #980).
 
 # CHANGES IN bookdown VERSION 0.21
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -574,8 +574,8 @@ lua_filter = function (filters = NULL) {
 
 # pass _bookdown.yml to Pandoc's Lua filters
 bookdown_yml_arg = function(config = load_config(), path = tempfile()) {
-  # this is supported for Pandoc >= 2.0 only
-  if (!pandoc2.0() || length(config) == 0) return()
+  # this is supported for Pandoc >= 2.3 only
+  if (!rmarkdown::pandoc_available('2.3') || length(config) == 0) return()
   yaml::write_yaml(list(bookdown = config), path)
   c("--metadata-file", rmarkdown::pandoc_path_arg(path))
 }


### PR DESCRIPTION
This fixes the dependency for --metadata-file to be on pandoc >= 2.3 (where it was introduced)

Closes #979

Signed-off-by: Mark Hymers <mark@hymers.org.uk>