### PR TITLE
Correctly relocate references with Pandoc 2.11

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bookdown
 Type: Package
 Title: Authoring Books and Technical Documents with R Markdown
-Version: 0.21.1
+Version: 0.21.2
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("JJ", "Allaire", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## BUG FIXES
 
-- References are now correctly relocated with Pandoc 2.11 when `split_bib = TRUE`.
+- References are now correctly relocated with Pandoc 2.11 when `split_bib = TRUE` in `gitbook()`. New citation processing in Pandoc 2.11 will also add new classes to the divs, and these are preserved when relocating. This allows for references styling using CSS (#981).
 
 - The new syntax for theorem and proof environments introduced in **bookdown** requires Pandoc >= 2.3 instead of 2.0 (thanks, @markhymers, #979 #980).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## BUG FIXES
 
+- References are now correctly relocated with Pandoc 2.11 when `split_bib = TRUE`.
+
 - The new syntax for theorem and proof environments introduced in **bookdown** requires Pandoc >= 2.3 instead of 2.0 (thanks, @markhymers, #979 #980).
 
 ## MINOR CHANGES

--- a/R/html.R
+++ b/R/html.R
@@ -348,7 +348,8 @@ split_chapters = function(output, build = build_chapter, number_sections, split_
   if (split_bib) {
     # parse and remove the references chapter
     res = parse_references(html_body)
-    refs = res$refs; html_body = res$html; ref_title = res$title
+    refs = res$refs; html_body = res$html
+    ref_title = res$title; refs_div = res$div
   }
   # parse and remove footnotes (will reassign them to relevant pages later)
   res = parse_footnotes(html_body)
@@ -415,7 +416,7 @@ split_chapters = function(output, build = build_chapter, number_sections, split_
     html = c(if (i == 1) html_title, html_body[i1:i2])
     a_targets = parse_a_targets(html)
     if (split_bib) {
-      html = relocate_references(html, refs, ref_title, a_targets)
+      html = relocate_references(html, refs, ref_title, a_targets, refs_div)
     }
     html = relocate_footnotes(html, fnts, a_targets)
     html = restore_links(html, html_body, idx, nms)
@@ -901,7 +902,8 @@ restore_appendix_html = function(x, remove = TRUE) {
 parse_references = function(x) {
   i = grep('^<div id="refs" class="references[^"]*">$', x)
   if (length(i) != 1) return(list(refs = character(), html = x))
-  r = '^<div id="(ref-[^"]+)".*>$'
+  regid = ' id="(ref-[^"]+)"'
+  r = sprintf('^<div%s.*>$', regid)
   k = grep(r, x)
   k = k[k > i]
   n = length(k)
@@ -917,18 +919,20 @@ parse_references = function(x) {
   ref = paste(x[k], ref, x[k + 2], sep = '\n')  # add <div id=ref-...></div>
   title = if (grepl('^<h1[^>]*>', x[i - 2]) && grepl('^<div ', x[i - 3]))
     gsub('<span class="header-section-number">[.0-9]+</span>', '', x[i - 2])
-  x[k] = '<div>'  # remove the div id's
+  x[k] = gsub(regid, "", x[k])  # remove the div id's but keep the classes
 
-  list(refs = setNames(ref, ids), html = x, title = title)
+  list(refs = setNames(ref, ids), html = x,
+       title = title, div = x[i])
 }
 
 # move references back to the relevant chapter
-relocate_references = function(x, refs, title, ids) {
+relocate_references = function(x, refs, title, ids, div) {
   if (length(refs) == 0) return(x)
   ids = intersect(names(refs), ids)
   if (length(ids) == 0) return(x)
   title = if (is.null(title)) '<h3>References</h3>' else gsub('h1>', 'h3>', title)
-  c(x, title, '<div id="refs" class="references">', refs[ids], '</div>')
+  if (is.null(div)) div = '<div id="refs" class="references">'
+  c(x, title, div , refs[ids], '</div>')
 }
 
 # extract relative links from text

--- a/R/html.R
+++ b/R/html.R
@@ -920,8 +920,7 @@ parse_references = function(x) {
     gsub('<span class="header-section-number">[.0-9]+</span>', '', x[i - 2])
   x[k] = gsub(r, "\\1\\3", x[k])  # remove the div id's
 
-  list(refs = setNames(ref, ids), html = x,
-       title = title, div = x[i])
+  list(refs = setNames(ref, ids), html = x, title = title, div = x[i])
 }
 
 # move references back to the relevant chapter

--- a/R/html.R
+++ b/R/html.R
@@ -902,14 +902,13 @@ restore_appendix_html = function(x, remove = TRUE) {
 parse_references = function(x) {
   i = grep('^<div id="refs" class="references[^"]*">$', x)
   if (length(i) != 1) return(list(refs = character(), html = x))
-  regid = ' id="(ref-[^"]+)"'
-  r = sprintf('^<div%s.*>$', regid)
+  r = '^(<div) id="(ref-[^"]+)"([^>]*>)$'
   k = grep(r, x)
   k = k[k > i]
   n = length(k)
   if (n == 0) return(list(refs = character(), html = x))
 
-  ids = gsub(r, '\\1', x[k])
+  ids = gsub(r, '\\2', x[k])
   ref = x[k + 1]
   # replace 3 em-dashes with author names
   dashes = paste0('^<p>', intToUtf8(rep(8212, 3)), '[.]')
@@ -919,7 +918,7 @@ parse_references = function(x) {
   ref = paste(x[k], ref, x[k + 2], sep = '\n')  # add <div id=ref-...></div>
   title = if (grepl('^<h1[^>]*>', x[i - 2]) && grepl('^<div ', x[i - 3]))
     gsub('<span class="header-section-number">[.0-9]+</span>', '', x[i - 2])
-  x[k] = gsub(regid, "", x[k])  # remove the div id's but keep the classes
+  x[k] = gsub(r, "\\1\\3", x[k])  # remove the div id's
 
   list(refs = setNames(ref, ids), html = x,
        title = title, div = x[i])

--- a/R/html.R
+++ b/R/html.R
@@ -901,7 +901,7 @@ restore_appendix_html = function(x, remove = TRUE) {
 parse_references = function(x) {
   i = grep('^<div id="refs" class="references[^"]*">$', x)
   if (length(i) != 1) return(list(refs = character(), html = x))
-  r = '^<div id="(ref-[^"]+)">$'
+  r = '^<div id="(ref-[^"]+)".*>$'
   k = grep(r, x)
   k = k[k > i]
   n = length(k)

--- a/R/utils.R
+++ b/R/utils.R
@@ -271,7 +271,7 @@ strip_html = function(x) {
 # remove the <script><script> content and references
 strip_search_text = function(x) {
   x = gsub('<script[^>]*>(.*?)</script>', '', x)
-  x = gsub('<div id="refs" class="references">.*', '', x)
+  x = gsub('<div id="refs" class="references[^"]*">.*', '', x)
   x = strip_html(x)
   x = gsub('[[:space:]]', ' ', x)
   x


### PR DESCRIPTION
This fixes #976 by modifying the regex to parse the references in HTML. 

Previously we had:
```html
<div id="refs" class="references">
<div id="ref-xie2015">
<p>Xie, Yihui. 2015. <em>Dynamic Documents with R and Knitr</em>. 2nd ed. Boca Raton, Florida: Chapman; Hall/CRC. <a href="http://yihui.name/knitr/">http://yihui.name/knitr/</a>.</p>
</div>
<div id="ref-R-bookdown">
<p>———. 2020. <em>Bookdown: Authoring Books and Technical Documents with R Markdown</em>. <a href="https://github.com/rstudio/bookdown">https://github.com/rstudio/bookdown</a>.</p>
</div>
</div>
```

 and now 
```html
<div id="refs" class="references csl-bib-body hanging-indent">
<div id="ref-xie2015" class="csl-entry">
Xie, Yihui. 2015. <em>Dynamic Documents with <span>R</span> and Knitr</em>. 2nd ed. Boca Raton, Florida: Chapman; Hall/CRC. <a href="http://yihui.name/knitr/">http://yihui.name/knitr/</a>.
</div>
<div id="ref-R-bookdown" class="csl-entry">
———. 2020. <em>Bookdown: Authoring Books and Technical Documents with r Markdown</em>. <a href="https://github.com/rstudio/bookdown">https://github.com/rstudio/bookdown</a>.
</div>
</div>
```

Some classes are added by Pandoc now when using `--citeproc`. 
I guess this allows for some customisation. 

This is note related to the issue, but let's note the span applied in the body have changed from 
```html
<span class="citation">(Xie <a href="#ref-R-bookdown" role="doc-biblioref">2020</a>)</span>
```
to 
```html
<span class="citation">(<a href="#ref-R-bookdown" role="doc-biblioref">Xie 2020</a>)</span>
```
So it applies by default to name and year, and not just year. 
I don't think this is an issue.
