### PR TITLE
Add default behavior for input in render_book by supporting a directory

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -47,12 +47,19 @@
 #' bookdown::render_book("index.Rmd", bookdown::pdf_book(toc = FALSE))
 #' }
 render_book = function(
-  input, output_format = NULL, ..., clean = TRUE, envir = parent.frame(),
+  input = NULL, output_format = NULL, ..., clean = TRUE, envir = parent.frame(),
   clean_envir = !interactive(), output_dir = NULL, new_session = NA,
   preview = FALSE, config_file = '_bookdown.yml'
 ) {
 
   verify_rstudio_version()
+  if (is.null(input) && file.exists("index.Rmd")) {
+    input = "index.Rmd"
+  } else {
+    stop(
+      "No index.Rmd file found in the current working directory.",
+      "You must specify an input Rmd.", call. = FALSE)
+  }
   format = NULL  # latex or html
   if (is.list(output_format)) {
     format = output_format$bookdown_output_format

--- a/R/render.R
+++ b/R/render.R
@@ -9,9 +9,11 @@
 #' (\code{new_session = FALSE}) is to merge Rmd files into a single file and
 #' render this file. You can also choose to render each individual Rmd file in a
 #' new R session (\code{new_session = TRUE}).
-#' @param input An input filename (or multiple filenames). If \code{preview =
-#'   TRUE}, only files specified in this argument are rendered, otherwise all R
-#'   Markdown files specified by the book are rendered.
+#' @param input A directory, an input filename or multiple filenames. For a
+#'   directory, \file{index.Rmd} will be used if it exists in this (book)
+#'   project directory. For filenames, if \code{preview = TRUE}, only files
+#'   specified in this argument are rendered, otherwise all R Markdown files
+#'   specified by the book are rendered.
 #' @param output_format,...,clean,envir Arguments to be passed to
 #'   \code{rmarkdown::\link{render}()}. For \code{preview_chapter()}, \code{...}
 #'   is passed to \code{render_book()}. See \code{rmarkdown::\link{render}()}
@@ -47,19 +49,23 @@
 #' bookdown::render_book("index.Rmd", bookdown::pdf_book(toc = FALSE))
 #' }
 render_book = function(
-  input = NULL, output_format = NULL, ..., clean = TRUE, envir = parent.frame(),
+  input = ".", output_format = NULL, ..., clean = TRUE, envir = parent.frame(),
   clean_envir = !interactive(), output_dir = NULL, new_session = NA,
   preview = FALSE, config_file = '_bookdown.yml'
 ) {
 
   verify_rstudio_version()
-  if (is.null(input) && file.exists("index.Rmd")) {
+
+  # select and check input file(s)
+  if (length(input) == 1L && file_test("-d", input)) {
+    message(sprintf("Rendering book in directory '%s'", input))
+    owd = setwd(input); on.exit(setwd(owd), add = TRUE)
     input = "index.Rmd"
-  } else {
-    stop(
-      "No index.Rmd file found in the current working directory.",
-      "You must specify an input Rmd.", call. = FALSE)
   }
+  if (!all(exist <- file_test("-f", input))) {
+    stop("Some files were not found: ",  paste(input[!exist], collapse = ' '))
+  }
+
   format = NULL  # latex or html
   if (is.list(output_format)) {
     format = output_format$bookdown_output_format

--- a/R/render.R
+++ b/R/render.R
@@ -47,6 +47,13 @@
 #' bookdown::render_book("index.Rmd",  "pdf_book")
 #' # If you pass an output format object, it must have all the options set
 #' bookdown::render_book("index.Rmd", bookdown::pdf_book(toc = FALSE))
+#'
+#' # will render the book in the current directory
+#' bookdown::render_book()
+#' # this is equivalent to
+#' bookdown::render_book("index.Rmd")
+#' # will render the book living in the specified directory
+#' bookdown::render_book("my_book_project")
 #' }
 render_book = function(
   input = ".", output_format = NULL, ..., clean = TRUE, envir = parent.frame(),

--- a/man/render_book.Rd
+++ b/man/render_book.Rd
@@ -77,5 +77,12 @@ bookdown::render_book("index.Rmd")
 bookdown::render_book("index.Rmd",  "pdf_book")
 # If you pass an output format object, it must have all the options set
 bookdown::render_book("index.Rmd", bookdown::pdf_book(toc = FALSE))
+
+# will render the book in the current directory
+bookdown::render_book()
+# this is equivalent to
+bookdown::render_book("index.Rmd")
+# will render the book living in the specified directory
+bookdown::render_book("my_book_project")
 }
 }

--- a/man/render_book.Rd
+++ b/man/render_book.Rd
@@ -6,7 +6,7 @@
 \title{Render multiple R Markdown documents into a book}
 \usage{
 render_book(
-  input = NULL,
+  input = ".",
   output_format = NULL,
   ...,
   clean = TRUE,
@@ -21,9 +21,11 @@ render_book(
 preview_chapter(..., envir = parent.frame())
 }
 \arguments{
-\item{input}{An input filename (or multiple filenames). If \code{preview =
-TRUE}, only files specified in this argument are rendered, otherwise all R
-Markdown files specified by the book are rendered.}
+\item{input}{A directory, an input filename or multiple filenames. For a
+directory, \file{index.Rmd} will be used if it exists in this (book)
+project directory. For filenames, if \code{preview = TRUE}, only files
+specified in this argument are rendered, otherwise all R Markdown files
+specified by the book are rendered.}
 
 \item{output_format, ..., clean, envir}{Arguments to be passed to
 \code{rmarkdown::\link{render}()}. For \code{preview_chapter()}, \code{...}
@@ -67,12 +69,12 @@ new R session (\code{new_session = TRUE}).
 }
 \examples{
 # see https://bookdown.org/yihui/bookdown for the full documentation
-if (file.exists("index.Rmd")) bookdown::render_book("index.Rmd")
+if (file.exists('index.Rmd')) bookdown::render_book('index.Rmd')
 \dontrun{
 # will use the default format defined in index.Rmd or _output.yml
 bookdown::render_book("index.Rmd")
 # will use the options for format defined in YAML metadata
-bookdown::render_book("index.Rmd", "pdf_book")
+bookdown::render_book("index.Rmd",  "pdf_book")
 # If you pass an output format object, it must have all the options set
 bookdown::render_book("index.Rmd", bookdown::pdf_book(toc = FALSE))
 }

--- a/man/render_book.Rd
+++ b/man/render_book.Rd
@@ -6,7 +6,7 @@
 \title{Render multiple R Markdown documents into a book}
 \usage{
 render_book(
-  input,
+  input = NULL,
   output_format = NULL,
   ...,
   clean = TRUE,


### PR DESCRIPTION
This will close #989 

Currently 

* `input` has no default value, but when it is not provided (i.e `render_book()` only), it will error. 
* `render_book` will assume it is run from the book project directory which is the working dir. One must use 
```r
xfun::in_dir("inst/examples", bookdown::render_book("index.Rmd"))
```
from the bookdown project for example 

This PR adds the ability to provide a directory to `render_book` (as is `serve_book`) and in that case it will use `index.Rmd` in that directory if it exists. 

* New default for `input` is current working directory, so `index.Rmd` will be used if it exists. 
* If a directory is provided, working is changed for that directory for the rendering (like in `serve_book`)
* There was not much assertation on that `input` argument so I added files' existences tests to stop early in case any of them does not exists. 

Now, with this PR, this is possible
```r
bookdown::render_book("inst/examples")
# or
xfun::in_dir("inst/examples", bookdown::render_book())
```
