### PR TITLE
Also match url with single quote when identifying resources to move.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## BUG FIXES
 
+- CSS dependencies like `url('truetype/Spectral-ExtraLight.ttf')` (with single quotes) are now correctly identified and moved (thanks, @RLesur, #991).
+
 - `fenced_theorems()` now correctly transforms implicit label in chunk header to a fenced divs id. (thanks, @enixam, #982)
 
 - References are now correctly relocated with Pandoc 2.11 when `split_bib = TRUE` in `gitbook()`. New citation processing in Pandoc 2.11 will also add new classes to the divs, and these are preserved when relocating. This allows for references styling using CSS (#981).

--- a/R/html.R
+++ b/R/html.R
@@ -1016,7 +1016,7 @@ move_files_html = function(output, lib_dir) {
   css = lapply(grep('[.]css$', f, ignore.case = TRUE, value = TRUE), function(z) {
     d = dirname(z)
     z = read_utf8(z)
-    r = 'url\\("?([^")]+)"?\\)'
+    r = 'url\\((?:"|\')?([^")\']+)(?:"|\')?\\)'
     lapply(regmatches(z, gregexpr(r, z)), function(s) {
       s = local_resources(gsub(r, '\\1', s))
       file.path(d, s)

--- a/R/html.R
+++ b/R/html.R
@@ -1016,7 +1016,7 @@ move_files_html = function(output, lib_dir) {
   css = lapply(grep('[.]css$', f, ignore.case = TRUE, value = TRUE), function(z) {
     d = dirname(z)
     z = read_utf8(z)
-    r = 'url\\((?:"|\')?([^")\']+)(?:"|\')?\\)'
+    r = 'url\\((?:"|\')?([^"\']+)(?:"|\')?\\)'
     lapply(regmatches(z, gregexpr(r, z)), function(s) {
       s = local_resources(gsub(r, '\\1', s))
       file.path(d, s)

--- a/R/html.R
+++ b/R/html.R
@@ -1017,10 +1017,8 @@ move_files_html = function(output, lib_dir) {
     d = dirname(z)
     z = read_utf8(z)
     r = 'url\\((?:"|\')?([^"\']+)(?:"|\')?\\)'
-    lapply(regmatches(z, gregexpr(r, z)), function(s) {
-      s = local_resources(gsub(r, '\\1', s))
-      file.path(d, s)
-    })
+    m = Filter(function(x) length(x)!=0, regmatches(z, regexec(r, z)))
+    file.path(d, local_resources(sapply(m, `[`, 2)))
   })
   f = c(f, unlist(css))
   f = gsub('[?#].+$', '', f)  # strip the #/? part in links, e.g. a.html#foo

--- a/R/html.R
+++ b/R/html.R
@@ -1016,9 +1016,11 @@ move_files_html = function(output, lib_dir) {
   css = lapply(grep('[.]css$', f, ignore.case = TRUE, value = TRUE), function(z) {
     d = dirname(z)
     z = read_utf8(z)
-    r = 'url\\((?:"|\')?([^"\']+)(?:"|\')?\\)'
-    m = Filter(function(x) length(x)!=0, regmatches(z, regexec(r, z)))
-    file.path(d, local_resources(sapply(m, `[`, 2)))
+    r = 'url\\((?:"|\')?([^")\']+)(?:"|\')?\\)'
+    lapply(regmatches(z, gregexpr(r, z)), function(s) {
+      s = local_resources(gsub(r, '\\1', s))
+      file.path(d, s)
+    })
   })
   f = c(f, unlist(css))
   f = gsub('[?#].+$', '', f)  # strip the #/? part in links, e.g. a.html#foo


### PR DESCRIPTION
fixes #991

We also match single quote with this regex. 

Checking:
``` r
z <- c("url(truetype/Spectral-ExtraLight.ttf)",
       "url(\"truetype/Spectral-ExtraLight.ttf\")",
       "url('truetype/Spectral-ExtraLight.ttf')",
       "dummy line")

r = 'url\\((?:"|\')?([^")\']+)(?:"|\')?\\)'

regmatches(z, regexec(r, z))
#> [[1]]
#> [1] "url(truetype/Spectral-ExtraLight.ttf)"
#> [2] "truetype/Spectral-ExtraLight.ttf"     
#> 
#> [[2]]
#> [1] "url(\"truetype/Spectral-ExtraLight.ttf\")"
#> [2] "truetype/Spectral-ExtraLight.ttf"         
#> 
#> [[3]]
#> [1] "url('truetype/Spectral-ExtraLight.ttf')"
#> [2] "truetype/Spectral-ExtraLight.ttf"       
#> 
#> [[4]]
#> character(0)
```

@yihui I left `regexpr` + `gsub`, but this is definitly a use case for `regexec`

@RLesur can you try with this PR ? 
