### PR TITLE
bring default.html in line with gitbook.html template

### DIFF
--- a/inst/templates/default.html
+++ b/inst/templates/default.html
@@ -8,7 +8,7 @@
 <meta property="og:title" content="$pagetitle$" />
 <meta property="og:type" content="book" />
 $if(url)$<meta property="og:url" content="$url$" />$endif$
-$if(cover-image)$<meta property="og:image" content="$url$$cover-image$" />$endif$
+$if(cover-image)$<meta property="og:image" content="$url$/$cover-image$" />$endif$
 $if(description)$<meta property="og:description" content="$description$" />$endif$
 $if(github-repo)$<meta name="github-repo" content="$github-repo$" />$endif$
 


### PR DESCRIPTION
I think #969 should have included this change as well, to make both templates work the same way with cover images.