### PR TITLE
Fix preview of Rmd file 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,7 +64,8 @@ Imports:
     rmarkdown (>= 2.4),
     xfun (>= 0.13),
     tinytex (>= 0.12),
-    yaml (>= 2.1.19)
+    yaml (>= 2.1.19),
+    xfun (>= 0.18)
 Suggests:
     htmlwidgets,
     rstudioapi,

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,10 +10,6 @@
 
 - The new syntax for theorem and proof environments introduced in **bookdown** requires Pandoc >= 2.3 instead of 2.0 (thanks, @markhymers, #979 #980).
 
-## MINOR CHANGES
-
-- `opts$get('input_rmd')` now stores original file path rather than basename, and when Rmd file under subdirectory changes, `serve_book()` will refresh correctly now (thanks, @shenfei, #834 #955).
-
 # CHANGES IN bookdown VERSION 0.21
 
 ## NEW FEATURES

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 - The new syntax for theorem and proof environments introduced in **bookdown** requires Pandoc >= 2.3 instead of 2.0 (thanks, @markhymers, #979 #980).
 
+- `serve_book()` will refresh correctly now when using subdirectories with `rmd_subdir` (thanks, @shenfei, #834).
+
 # CHANGES IN bookdown VERSION 0.21
 
 ## NEW FEATURES

--- a/R/render.R
+++ b/R/render.R
@@ -92,7 +92,7 @@ render_book = function(
   if (!preview) unlink(ref_keys_path(output_dir))  # clean up reference-keys.txt
   # store output directory and the initial input Rmd name
   opts$set(
-    output_dir = output_dir, input_rmd = input, preview = preview
+    output_dir = output_dir, input_rmd = basename(input), preview = preview
   )
 
   aux_diro = '_bookdown_files'

--- a/R/render.R
+++ b/R/render.R
@@ -92,7 +92,9 @@ render_book = function(
   if (!preview) unlink(ref_keys_path(output_dir))  # clean up reference-keys.txt
   # store output directory and the initial input Rmd name
   opts$set(
-    output_dir = output_dir, input_rmd = basename(input), preview = preview
+    output_dir = output_dir,
+    input_rmd = xfun::relative_path(input, dir = "."),
+    preview = preview
   )
 
   aux_diro = '_bookdown_files'


### PR DESCRIPTION
This will fix #1003 by modifying the fix of #834 done in #955 

The previous fix was ok for `serve_book` and subdirectories, but it broke some stuff (that we did not see... hard to test also currently)

Removing `basename` was way to agressive because sometimes absolute path can be pass as `input` (ex. in `render_site`). 
All **bookdown** filename comparaison are with relative path - so having an absolute path in `opt$get('input_rmd')` was breaking everything that needs a relative path. 

This new fix use `xfun::relative_path` based on the current working dir that `render_book` is running from. 

This should fix the subdirectory issue while not breaking the preview feature. 

cc @shenfei as I modified your initial fix. 