### PR TITLE
Improve copy UX on bs4_book (#1040)

### DIFF
--- a/inst/resources/bs4_book/bs4_book.css
+++ b/inst/resources/bs4_book/bs4_book.css
@@ -354,6 +354,10 @@ mark {
 
 /* Code ------------------------------------------------ */
 
+div.sourceCode {
+  position: relative;
+}
+
 pre {
   position: relative;
   overflow: auto;
@@ -392,16 +396,24 @@ code a:any-link {
   text-decoration-color: #ccc;
 }
 
-pre .copy {
+.sourceCode .copy {
   position: absolute;
   top: 0.5rem;
   right: 0.5rem;
 }
-pre .copy button {
+
+.sourceCode .copy button {
   background-color: #fff;
   font-size: 80%;
   padding: 4px 6px;
+  visibility: hidden;
 }
+
+
+.sourceCode:hover > .copy button {
+  visibility: visible;
+}
+
 
 /* https://github.com/rstudio/distill/blob/master/inst/rmarkdown/templates/distill_article/resources/a11y.theme + https://gist.github.com/hadley/f53b6e92df20994fdabe6562d284728a */
 code span.ot {color:#007faa}

--- a/inst/resources/bs4_book/bs4_book.css
+++ b/inst/resources/bs4_book/bs4_book.css
@@ -398,8 +398,8 @@ code a:any-link {
 
 .sourceCode .copy {
   position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
+  top: 0.2rem;
+  right: 0.2rem;
 }
 
 .sourceCode .copy button {

--- a/inst/resources/bs4_book/bs4_book.js
+++ b/inst/resources/bs4_book/bs4_book.js
@@ -109,7 +109,7 @@ $(document).ready(function() {
   if(ClipboardJS.isSupported()) {
     // Insert copy buttons
     var copyButton = "<div class='copy'><button type='button' class='btn btn-outline-primary btn-copy' title='Copy to clipboard' aria-label='Copy to clipboard' data-toggle='popover' data-placement='top' data-trigger='hover'>Copy</button></div>";
-    $(copyButton).appendTo("pre");
+    $(copyButton).appendTo("div.sourceCode");
     // Initialize tooltips:
     $('.btn-copy').tooltip({container: 'body', boundary: 'window'});
 


### PR DESCRIPTION
Improves ux of copy to clipboard:

1.  Copy only appears on input code blocks
2.  Only on mouseover
3.  Copy button remains fixed during scroll
4.  Copy button repositioned marginally for better look on single code lines