### PR TITLE
Improved intermediate cleanup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 
 - Added the same CSS as in default Pandoc's template for when a CSL is used (#1045).   
 
+- `render_book()` now correctly cleans up intermediate files if a built is interrupted part way through (#986).
+
 ## MINOR CHANGES
 
 - `anchor_sections = TRUE` becomes the default for `bookdown::gitbook()`.

--- a/R/render.R
+++ b/R/render.R
@@ -187,10 +187,10 @@ render_cur_session = function(files, main, config, output_format, clean, envir, 
 render_new_session = function(files, main, config, output_format, clean, envir, ...) {
 
   # save a copy of render arguments in a temp file
-  render_args = tempfile('render', '.', '.rds')
+  render_args = tempfile('render', fileext = '.rds')
   on.exit(file.remove(render_args), add = TRUE)
   saveRDS(
-    list(output_format = output_format, ..., clean = FALSE, envir = envir),
+    list(output_format = output_format, ..., clean = clean, envir = envir),
     render_args
   )
   # an RDS file to save all the metadata after compiling each Rmd
@@ -207,6 +207,7 @@ render_new_session = function(files, main, config, output_format, clean, envir, 
   add2 = merge_chapter_script(config, 'after')
   on.exit(unlink(c(add1, add2)), add = TRUE)
   # compile chapters in separate R sessions
+  on.exit(unlink(with_ext(files, '.md')), add = TRUE)
   for (f in files[rerun]) Rscript_render(f, render_args, render_meta, add1, add2)
 
   if (!all(dirname(files_md) == '.'))


### PR DESCRIPTION
* Save render args in tempdir()
* Pass clean argument to chapter render
* Delete intermediate .md files

Fixes #986

I don't 100% follow the intent of this code, so I'm not sure if these are the correct fixes, but they resolve the problem for me, and I'm happy to respond to feedback.