### PR TITLE
Add a vectorized wrapper for xfun::relative_path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 
 - Added the same CSS as in default Pandoc's template for when a CSL is used (#1045).   
 
+- No more warnings are thrown when passing several input files to `render_book(preview = TRUE)` (#1091).
+
 ## MINOR CHANGES
 
 - `anchor_sections = TRUE` becomes the default for `bookdown::gitbook()`.

--- a/R/render.R
+++ b/R/render.R
@@ -113,7 +113,7 @@ render_book = function(
   # store output directory and the initial input Rmd name
   opts$set(
     output_dir = output_dir,
-    input_rmd = xfun::relative_path(input, dir = "."),
+    input_rmd = relative_path(input),
     preview = preview
   )
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -284,6 +284,12 @@ dir_create = function(path) {
   dir_exists(path) || dir.create(path, recursive = TRUE)
 }
 
+# vectorized version to get relative path of multiple input
+relative_path = function(inputs, dir = ".") {
+  f = Vectorize(xfun::relative_path, "x", USE.NAMES = FALSE)
+  f(x = inputs, dir = dir, use.. = TRUE, error = TRUE)
+}
+
 # a wrapper of file.path to ignore `output_dir` if it is NULL
 output_path = function(...) {
   dir = opts$get('output_dir')

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -165,3 +165,8 @@ assert('fence_theorems() converts the knitr engine syntax to fenced Divs', {
   res = fence_theorems(text = old)
   (unclass(res) %==% old)
 })
+
+assert("relative_path is vectorized", {
+  relative_path(c('foo/bar.txt', 'foo/baz.txt'), 'foo/') %==% c("bar.txt", "baz.txt")
+  relative_path('foo/bar.txt', 'foo') %==% "bar.txt"
+})


### PR DESCRIPTION
To handle several inputs in `render_book(input=)`. Currently it seems to work but we have warnings thrown in `xfun::relative_path`
```r
Warning messages:
1: In if ((n1 <- nchar(p)) == 0) return(x) :
  the condition has length > 1 and only the first element will be used
2: In if (is_sub_path(p, d, n2)) { :
  the condition has length > 1 and only the first element will be used
3: In if (p2 == "") p2 = "." :
  the condition has length > 1 and only the first element will be used
```
Reported in #1090 

Other solution would be to make `xfun` functions vectorized. @yihui would that be better ? 

This type of situation make me feels we are trying to recreate / maintain / tests some functionality we could get elsewhere : **fs** package is rather low level with no dependency and could help power all the path handling in the packages. Just throwing the idea in case this is a project we want to tackle.