### PR TITLE
Fix nesting of multiple authors/affiliations in gitbook.html template.  Add conditional styling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 
 - Added the same CSS as in default Pandoc's template for when a CSL is used (#1045).   
 
+- Properly support multiple authors in the `gitbook()` output format (thanks, @adamvi, #1095).
+
 - No more warnings are thrown when passing several input files to `render_book(preview = TRUE)` (#1091).
 
 ## MINOR CHANGES

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -126,9 +126,10 @@ $if(author.name)$
 <p class="author"><em>$author.name$</em></p>
 $if(author.affiliation)$
 <address class="author_afil">
-$author.affiliation$<br>$endif$
+$author.affiliation$<br>
 $if(author.email)$
 <a class="author_email" href="mailto:#">$author.email$</a>
+$endif$
 </address>
 $endif$
 $else$

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -123,6 +123,15 @@ $if(subtitle)$
 $endif$
 $for(author)$
 $if(author.name)$
+<style type="text/css">
+  #header p.author {
+    margin-top: 1em;
+    margin-bottom: 0em;
+  }
+  #header p.date {
+    margin-top: 1.5em;
+  }
+</style>
 <p class="author"><em>$author.name$</em></p>
 $if(author.affiliation)$
 <address class="author_afil">

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -124,11 +124,10 @@ $endif$
 $for(author)$
 $if(author.name)$
 <style type="text/css">
-  #header p.author {
-    margin-top: 1em;
-    margin-bottom: 0em;
+  p.author {
+    margin: 1em 0 0 0;
   }
-  #header p.date {
+  p.date {
     margin-top: 1.5em;
   }
 </style>


### PR DESCRIPTION
Not a huge problem, but the nesting of authors and affiliations gets mangled due to misplace $endif$.  Also added some css styling in these cases to separate the author affiliations.  Attached is a screenshot of what the styling effects are.
![Proposed_Fix](https://user-images.githubusercontent.com/1299659/110530513-c8325d80-80d7-11eb-89ad-444d08420e03.png)
