### PR TITLE
Move css to inline HTML style. CSS ineffective without #header.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 
 - Added the same CSS as in default Pandoc's template for when a CSL is used (#1045).   
 
+- Properly support multiple authors in the `gitbook()` output format (thanks, @adamvi, #1095).
+
 - No more warnings are thrown when passing several input files to `render_book(preview = TRUE)` (#1091).
 
 ## MINOR CHANGES

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -123,7 +123,7 @@ $if(subtitle)$
 $endif$
 $for(author)$
 $if(author.name)$
-<p class="author" style="margin: 1em 0 -0.5em 0; background: yellow;"><em>$author.name$</em></p>
+<p class="author" style="margin: 1em 0 -0.5em 0;"><em>$author.name$</em></p>
 $if(author.affiliation)$
 <address class="author_afil">
 $author.affiliation$<br>

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -124,6 +124,7 @@ $endif$
 $for(author)$
 $if(author.name)$
 $if(author.affiliation)$
+<p class="author" style="margin: 1em 0 -0.5em 0; background: yellow;"><em>$author.name$</em></p>
 <address class="author_afil">
 $author.affiliation$<br>
 $if(author.email)$

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -123,7 +123,7 @@ $if(subtitle)$
 $endif$
 $for(author)$
 $if(author.name)$
-<p class="author" style="margin: 1em 0 -0.5em 0;"><em>$author.name$</em></p>
+<p class="author" style="margin: 0.5em 0 -0.5em 0;"><em>$author.name$</em></p>
 $if(author.affiliation)$
 <address class="author_afil">
 $author.affiliation$<br>

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -126,9 +126,10 @@ $if(author.name)$
 <p class="author"><em>$author.name$</em></p>
 $if(author.affiliation)$
 <address class="author_afil">
-$author.affiliation$<br>$endif$
+$author.affiliation$<br>
 $if(author.email)$
 <a class="author_email" href="mailto:#">$author.email$</a>
+$endif$
 </address>
 $endif$
 $else$

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -123,8 +123,8 @@ $if(subtitle)$
 $endif$
 $for(author)$
 $if(author.name)$
-$if(author.affiliation)$
 <p class="author" style="margin: 1em 0 -0.5em 0; background: yellow;"><em>$author.name$</em></p>
+$if(author.affiliation)$
 <address class="author_afil">
 $author.affiliation$<br>
 $if(author.email)$

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -137,7 +137,7 @@ $else$
 $endif$
 $endfor$
 $if(date)$
-<p class="date" style="margin-top: 1.5em"><em>$date$</em></p>
+<p class="date" style="margin-top: 1.5em;"><em>$date$</em></p>
 $endif$
 $if(abstract)$
 <div class="abstract">

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -123,15 +123,7 @@ $if(subtitle)$
 $endif$
 $for(author)$
 $if(author.name)$
-<style type="text/css">
-  p.author {
-    margin: 1em 0 0 0;
-  }
-  p.date {
-    margin-top: 1.5em;
-  }
-</style>
-<p class="author"><em>$author.name$</em></p>
+<p class="author" style="margin: 1em 0 -0.5em 0;"><em>$author.name$</em></p>
 $if(author.affiliation)$
 <address class="author_afil">
 $author.affiliation$<br>
@@ -145,7 +137,7 @@ $else$
 $endif$
 $endfor$
 $if(date)$
-<p class="date"><em>$date$</em></p>
+<p class="date" style="margin-top: 1.5em"><em>$date$</em></p>
 $endif$
 $if(abstract)$
 <div class="abstract">

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -123,6 +123,15 @@ $if(subtitle)$
 $endif$
 $for(author)$
 $if(author.name)$
+<style type="text/css">
+  #header p.author {
+    margin-top: 1em;
+    margin-bottom: 0em;
+  }
+  #header p.date {
+    margin-top: 1.5em;
+  }
+</style>
 <p class="author"><em>$author.name$</em></p>
 $if(author.affiliation)$
 <address class="author_afil">

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -124,11 +124,10 @@ $endif$
 $for(author)$
 $if(author.name)$
 <style type="text/css">
-  #header p.author {
-    margin-top: 1em;
-    margin-bottom: 0em;
+  p.author {
+    margin: 1em 0 0 0;
   }
-  #header p.date {
+  p.date {
     margin-top: 1.5em;
   }
 </style>


### PR DESCRIPTION
By moving the CSS inline we keep the style changes without the CSS.  This can be changed with CSS override by users - see [here](https://css-tricks.com/override-inline-styles-with-css/).

The proposed changes result in the following output:

###  Single author, no affiliation (most basic - note it will change the spacing between author and date from the original)

![Single_auth_no_affil](https://user-images.githubusercontent.com/1299659/110667519-91b41b80-8187-11eb-8cc8-54887f2acfc7.png)

###  Multiple authors, no affiliation (color background added for context)

![Auth_no_affil_proposed](https://user-images.githubusercontent.com/1299659/110667711-c45e1400-8187-11eb-81b2-c5c298d25506.png)

###  Multiple authors with affiliation (color background added for context)

![Auth_w_affil_proposed](https://user-images.githubusercontent.com/1299659/110667724-c88a3180-8187-11eb-99d8-3374c125ce76.png)
