### PR TITLE
toc_bib works with biblatex

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 ## BUG FIXES
 
+- In `pdf_book()`, `toc_bib = TRUE` now works with _natbib_ and _biblatex_ as `citation_package` (thanks, @qifei9, @umarcor, #450).
+
 - CSS dependencies like `url('truetype/Spectral-ExtraLight.ttf')` (with single quotes) are now correctly identified and moved (thanks, @RLesur, #991).
 
 - `fenced_theorems()` now correctly transforms implicit label in chunk header to a fenced divs id. (thanks, @enixam, #982)

--- a/R/latex.R
+++ b/R/latex.R
@@ -203,12 +203,14 @@ add_toc_bib = function(x) {
   r = '^\\s*\\\\bibliography\\{.+\\}$'
   i = grep(r, x)
   if (length(i) != 0) {
-    # natbib
+    # natbib - add toc manually using \bibname
+    # e.g adding \addcontentsline{toc}{chapter}{\bibname}
     i = i[1]
     level = if (length(grep('^\\\\chapter\\*?\\{', x))) 'chapter' else 'section'
     x[i] = sprintf('%s\n\\addcontentsline{toc}{%s}{\\bibname}', x[i], level)
   } else {
-    # biblatex
+    # biblatex - add heading=bibintoc in options
+    # e.g \printbibliography[title=References,heading=bibintoc]
     r = '^(\\s*\\\\printbibliography)(\\[.*\\])?$'
     i = grep(r, x)
     if (length(i) == 0) return(x)

--- a/R/latex.R
+++ b/R/latex.R
@@ -199,13 +199,29 @@ remove_toc_items = function(x) {
 }
 
 add_toc_bib = function(x) {
-  # regex for 'natbib | biblatex'
-  r = '^\\s*\\\\bibliography\\{.+\\}$|^\\s*\\\\printbibliography(\\[.*\\])?$'
+  # natbib
+  r = '^\\s*\\\\bibliography\\{.+\\}$'
   i = grep(r, x)
-  if (length(i) == 0) return(x)
-  i = i[1]
-  level = if (length(grep('^\\\\chapter\\*?\\{', x))) 'chapter' else 'section'
-  x[i] = sprintf('%s\n\\addcontentsline{toc}{%s}{\\bibname}', x[i], level)
+  if (length(i) != 0) {
+    # natbib
+    i = i[1]
+    level = if (length(grep('^\\\\chapter\\*?\\{', x))) 'chapter' else 'section'
+    x[i] = sprintf('%s\n\\addcontentsline{toc}{%s}{\\bibname}', x[i], level)
+  } else {
+    # biblatex
+    r = '^(\\s*\\\\printbibliography)(\\[.*\\])?$'
+    i = grep(r, x)
+    if (length(i) == 0) return(x)
+    opts = gsub(r, "\\2", x)
+    bibintoc = "heading=bibintoc"
+    if (nzchar(opts)) {
+      opts2 = gsub("^\\[(.*)\\]$", "\\1", opts)
+      opts = if (!grepl("heading=", opts2)) sprintf("[%s,%s]", opts2, bibintoc)
+    } else (
+      opts = sprintf("[%s]", bibintoc)
+    )
+    x[i] = sprintf('%s%s', gsub(r, "\\1", x), opts)
+  }
   x
 }
 

--- a/R/latex.R
+++ b/R/latex.R
@@ -212,7 +212,7 @@ add_toc_bib = function(x) {
     r = '^(\\s*\\\\printbibliography)(\\[.*\\])?$'
     i = grep(r, x)
     if (length(i) == 0) return(x)
-    opts = gsub(r, "\\2", x)
+    opts = gsub(r, "\\2", x[i])
     bibintoc = "heading=bibintoc"
     if (nzchar(opts)) {
       opts2 = gsub("^\\[(.*)\\]$", "\\1", opts)
@@ -220,7 +220,7 @@ add_toc_bib = function(x) {
     } else (
       opts = sprintf("[%s]", bibintoc)
     )
-    x[i] = sprintf('%s%s', gsub(r, "\\1", x), opts)
+    x[i] = sprintf('%s%s', gsub(r, "\\1", x[i]), opts)
   }
   x
 }

--- a/R/latex.R
+++ b/R/latex.R
@@ -199,7 +199,8 @@ remove_toc_items = function(x) {
 }
 
 add_toc_bib = function(x) {
-  r = '^\\\\bibliography\\{.+\\}$'
+  # regex for 'natbib | biblatex'
+  r = '^\\s*\\\\bibliography\\{.+\\}$|^\\s*\\\\printbibliography(?:\\[[^]]\\])?$'
   i = grep(r, x)
   if (length(i) == 0) return(x)
   i = i[1]

--- a/R/latex.R
+++ b/R/latex.R
@@ -200,7 +200,7 @@ remove_toc_items = function(x) {
 
 add_toc_bib = function(x) {
   # regex for 'natbib | biblatex'
-  r = '^\\s*\\\\bibliography\\{.+\\}$|^\\s*\\\\printbibliography(?:\\[[^]]\\])?$'
+  r = '^\\s*\\\\bibliography\\{.+\\}$|^\\s*\\\\printbibliography(\\[.*\\])?$'
   i = grep(r, x)
   if (length(i) == 0) return(x)
   i = i[1]

--- a/tests/testit/test-latex.R
+++ b/tests/testit/test-latex.R
@@ -7,7 +7,7 @@ assert("insert TeX syntax for bib in toc correctly", {
   (add_toc_bib("\\bibliography{bib1.bib,bib2.bib}") %==%
     "\\bibliography{bib1.bib,bib2.bib}\n\\addcontentsline{toc}{section}{\\bibname}")
   (add_toc_bib("\\printbibliography") %==%
-    "\\printbibliography\n\\addcontentsline{toc}{section}{\\bibname}")
+    "\\printbibliography[heading=bibintoc]")
   (add_toc_bib("\\printbibliography[title=References]") %==%
-    "\\printbibliography[title=References]\n\\addcontentsline{toc}{section}{\\bibname}")
+    "\\printbibliography[title=References,heading=bibintoc]")
 })

--- a/tests/testit/test-latex.R
+++ b/tests/testit/test-latex.R
@@ -1,0 +1,13 @@
+library(testit)
+
+assert("insert TeX syntax for bib in toc correctly", {
+  (add_toc_bib("\\anything else unchanged") %==% "\\anything else unchanged")
+  (add_toc_bib("\\bibliography{bib1.bib}") %==%
+    "\\bibliography{bib1.bib}\n\\addcontentsline{toc}{section}{\\bibname}")
+  (add_toc_bib("\\bibliography{bib1.bib,bib2.bib}") %==%
+    "\\bibliography{bib1.bib,bib2.bib}\n\\addcontentsline{toc}{section}{\\bibname}")
+  (add_toc_bib("\\printbibliography") %==%
+    "\\printbibliography\n\\addcontentsline{toc}{section}{\\bibname}")
+  (add_toc_bib("\\printbibliography[title=References]") %==%
+    "\\printbibliography[title=References]\n\\addcontentsline{toc}{section}{\\bibname}")
+})

--- a/tests/testit/test-latex.R
+++ b/tests/testit/test-latex.R
@@ -2,6 +2,8 @@ library(testit)
 
 assert("insert TeX syntax for bib in toc correctly", {
   (add_toc_bib("\\anything else unchanged") %==% "\\anything else unchanged")
+  (add_toc_bib(c("dummyline", "\\bibliography{bib1.bib}")) %==%
+    c("dummyline", "\\bibliography{bib1.bib}\n\\addcontentsline{toc}{section}{\\bibname}"))
   (add_toc_bib("\\bibliography{bib1.bib}") %==%
     "\\bibliography{bib1.bib}\n\\addcontentsline{toc}{section}{\\bibname}")
   (add_toc_bib("\\bibliography{bib1.bib,bib2.bib}") %==%
@@ -10,4 +12,6 @@ assert("insert TeX syntax for bib in toc correctly", {
     "\\printbibliography[heading=bibintoc]")
   (add_toc_bib("\\printbibliography[title=References]") %==%
     "\\printbibliography[title=References,heading=bibintoc]")
+  (add_toc_bib(c("dummyline", "\\printbibliography[title=References]")) %==%
+    c("dummyline", "\\printbibliography[title=References,heading=bibintoc]"))
 })


### PR DESCRIPTION
This will close #450 and also fixed `toc_bib` that was no more working because of indentation in tex template. 

Basically, natbib and biblatex does not include the same syntax. See Pandoc's template: https://github.com/jgm/pandoc/blob/master/data/templates/default.latex
which was explained in the issue.

Also, the trick for natbib does not work for bibtex. We need to use another syntax. 
I choose to modify the tex line with regex to add the option `heading=bibintoc`.
Other solution would have been to add `\DeclarePrintbibliographyDefaults{heading=bibintoc}` in preamble. This seems more complicated from within `add_toc_bib()` function and it works only with recent biblatex (https://tex.stackexchange.com/a/544718/209358)

I added test that help me fix already some edge cases.

I tested manually on bookdown-demo using

* `citation_package: biblatex` or `citation_package: natbib`
* with `biblio-title: References` in index.Rmd
