### PR TITLE
Also parse references in footnotes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 ## BUG FIXES
 
+- When `split_bib = TRUE`, references in footnotes are now also correctly relocated in the chapter (thanks, @jimhshen, #952)
+
 - In `pdf_book()`, `toc_bib = TRUE` now works with _natbib_ and _biblatex_ as `citation_package` (thanks, @qifei9, @umarcor, #450).
 
 - CSS dependencies like `url('truetype/Spectral-ExtraLight.ttf')` (with single quotes) are now correctly identified and moved (thanks, @RLesur, #991).

--- a/R/html.R
+++ b/R/html.R
@@ -415,9 +415,9 @@ split_chapters = function(output, build = build_chapter, number_sections, split_
     i2 = if (i == n) length(html_body) else idx[i + 1] - 1
     html = c(if (i == 1) html_title, html_body[i1:i2])
     a_targets = parse_a_targets(html)
-    # in order to find references in footnotes, we add footnotes to chapter body
-    a_targets = parse_a_targets(relocate_footnotes(html, fnts, a_targets))
     if (split_bib) {
+      # in order to find references in footnotes, we add footnotes to chapter body
+      a_targets = parse_a_targets(relocate_footnotes(html, fnts, a_targets))
       html = relocate_references(html, refs, ref_title, a_targets, refs_div)
     }
     html = relocate_footnotes(html, fnts, a_targets)

--- a/R/html.R
+++ b/R/html.R
@@ -415,6 +415,8 @@ split_chapters = function(output, build = build_chapter, number_sections, split_
     i2 = if (i == n) length(html_body) else idx[i + 1] - 1
     html = c(if (i == 1) html_title, html_body[i1:i2])
     a_targets = parse_a_targets(html)
+    # in order to find references in footnotes, we add footnotes to chapter body
+    a_targets = parse_a_targets(relocate_footnotes(html, fnts, a_targets))
     if (split_bib) {
       html = relocate_references(html, refs, ref_title, a_targets, refs_div)
     }
@@ -946,7 +948,7 @@ parse_a_targets = function(x) {
   unlist(lapply(regmatches(x, gregexpr(r, x)), function(target) {
     if (length(target) == 0) return()
     gsub(r, '\\1', target)
-  }))
+  }), use.names = FALSE)
 }
 
 # parse footnotes in the div of class "footnotes"; each footnote is one <li>


### PR DESCRIPTION
This PR solves #952 by modifying the order in which looking for the targets ids. 

1. We first gets href= in <a> targets to retrieve relevant footnote
2. We then rerun the function to get href in body + relocated footnote
3. We use the full identified ids to find the references and append to body
4. we rerun footnote relocation so that footnotes are appended after references

Tested with the reproducible example given: https://github.com/jimhshen/citationfootnotes