### PR TITLE
Allow use of a function for fig, eq or tab labels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bookdown
 Type: Package
 Title: Authoring Books and Technical Documents with R Markdown
-Version: 0.21.7
+Version: 0.21.8
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("JJ", "Allaire", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 - `hypothesis` environment is now supported among [Theorems and Proof](https://bookdown.org/yihui/bookdown/markdown-extensions-by-bookdown.html#theorems) (thanks, @shirdekel, #1102).
 
+- In `_bookdown.yaml`, `label` fields `fig`, `tab` and `eq` can now take a function as `ui` fields `chapter_name` and `appendix`. This function takes the reference number as only argument and must return a character to be used as full label. The default is a string prepended before the reference number. This new feature gives more flexibility to change the default for other language, e.g append the label name after the number. See updated doc about [Internationalization](https://bookdown.org/yihui/bookdown/internationalization.html)(thanks, Tamás Ferenc, #1114)
+
 ## BUG FIXES
 
 - Adapt CSS in `gitbook()` and `html_book()` for correct diplaying of `<details><summary>` content (thanks, @maelle, #971)

--- a/R/ebook.R
+++ b/R/ebook.R
@@ -117,8 +117,10 @@ resolve_refs_md = function(content, ref_table, to_md = output_md()) {
         if (type %in% theorem_abbr) {
           id = sprintf('<span id="%s"></span>', j)
           sep = ''
+          label = paste0(id, label_prefix(type), ref_table[j], sep, ' ')
+        } else {
+          label = label_fun(type, sep = sep)(ref_table[j])
         }
-        label = label_fun(type, sep = sep)(ref_table[j])
         content[i] = sub(
           m, paste0(id, label, ' '), content[i]
         )

--- a/R/ebook.R
+++ b/R/ebook.R
@@ -117,10 +117,8 @@ resolve_refs_md = function(content, ref_table, to_md = output_md()) {
         if (type %in% theorem_abbr) {
           id = sprintf('<span id="%s"></span>', j)
           sep = ''
-          label = paste0(id, label_prefix(type), ref_table[j], sep, ' ')
-        } else {
-          label = label_fun(type, sep = sep)(ref_table[j])
         }
+        label = label_prefix(type, sep = sep)(ref_table[j])
         content[i] = sub(
           m, paste0(id, label, ' '), content[i]
         )

--- a/R/ebook.R
+++ b/R/ebook.R
@@ -114,13 +114,13 @@ resolve_refs_md = function(content, ref_table, to_md = output_md()) {
       if (grepl(m, content[i])) {
         id = ''; sep = ':'
         type = gsub('^([^:]+).*$', '\\1', j)
-        if (type %in% names(theorem_abbr)) {
+        if (type %in% theorem_abbr) {
           id = sprintf('<span id="%s"></span>', j)
           sep = ''
         }
-        label = label_prefix(type)
+        label = label_fun(type, sep = sep)(ref_table[j])
         content[i] = sub(
-          m, paste0(id, label, ref_table[j], sep, ' '), content[i]
+          m, paste0(id, label, ' '), content[i]
         )
         break
       }

--- a/R/html.R
+++ b/R/html.R
@@ -694,6 +694,11 @@ parse_fig_labels = function(content, global = FALSE) {
 
 # given a label, e.g. fig:foo, figure out the appropriate prefix
 label_prefix = function(type, dict = label_names) i18n('label', type, dict)
+label_fun = function(type, sep) {
+  label = label_prefix(type)
+  if (is.function(label)) return(label)
+  function(num) paste0(label, num, sep)
+}
 
 ui_names = list(edit = 'Edit', chapter_name = '', appendix_name = '')
 ui_language = function(key, dict = ui_names) i18n('ui', key, ui_names)

--- a/R/html.R
+++ b/R/html.R
@@ -696,7 +696,7 @@ parse_fig_labels = function(content, global = FALSE) {
 label_prefix = function(type, dict = label_names, sep = '') {
   label = i18n('label', type, dict)
   supported_type = c('fig', 'tab', 'eq')
-  if (is.function(type)) {
+  if (is.function(label)) {
     if (type %in% supported_type) return(label)
     msg = knitr::combine_words(supported_type)
     stop("Using a function is only supported for ", msg)

--- a/R/html.R
+++ b/R/html.R
@@ -678,7 +678,7 @@ parse_fig_labels = function(content, global = FALSE) {
         '(<span class="math display")', sprintf('\\1 id="%s"', lab), content[k]
       )
     }, {
-      labs[[i]] = label_fun(type, sep = ' ')(num)
+      labs[[i]] = paste0(label_prefix(type), num, ' ')
     })
   }
 

--- a/R/html.R
+++ b/R/html.R
@@ -663,13 +663,13 @@ parse_fig_labels = function(content, global = FALSE) {
         labs[[i]] = character(length(lab))
         next
       }
-      labs[[i]] = paste0(label_prefix(type), num, ': ')
+      labs[[i]] = label_fun(type, sep = ': ')(num)
       k = max(figs[figs <= i])
       content[k] = paste(c(content[k], sprintf('<span id="%s"></span>', lab)), collapse = '')
     }, tab = {
       if (length(grep('^\\s*<caption', content[i - 0:1])) == 0) next
-      labs[[i]] = sprintf(
-        '<span id="%s">%s</span>', lab, paste0(label_prefix(type), num, ': ')
+      labs[[i]] = sprintf('<span id="%s">%s</span>',
+                          lab, label_fun(type, sep = ': ')(num)
       )
     }, eq = {
       labs[[i]] = sprintf('\\tag{%s}', num)
@@ -678,7 +678,7 @@ parse_fig_labels = function(content, global = FALSE) {
         '(<span class="math display")', sprintf('\\1 id="%s"', lab), content[k]
       )
     }, {
-      labs[[i]] = paste0(label_prefix(type), num, ' ')
+      labs[[i]] = label_fun(type, sep = ' ')(num)
     })
   }
 

--- a/R/latex.R
+++ b/R/latex.R
@@ -238,10 +238,8 @@ restore_block2 = function(x, global = FALSE) {
       lapply(theorem_abbr, label_prefix),
       function(fun) fun(), character(1), USE.NAMES = FALSE)
     theorem_defs = sprintf(
-      '%s\\newtheorem{%s}{%s}%s',
-      theorem_style(names(theorem_abbr)),
-      names(theorem_abbr),
-      str_trim(theorem_label),
+      '%s\\newtheorem{%s}{%s}%s', theorem_style(names(theorem_abbr)),
+      names(theorem_abbr), str_trim(theorem_label),
       if (global) '' else {
         if (length(grep('^\\\\chapter[*]?', x))) '[chapter]' else '[section]'
       }

--- a/R/latex.R
+++ b/R/latex.R
@@ -234,18 +234,26 @@ restore_block2 = function(x, global = FALSE) {
   # fenced div (\begin) is used
   if (length(grep(sprintf('^\\\\(BeginKnitrBlock|begin)\\{(%s)\\}', paste(all_math_env, collapse = '|')), x)) &&
       length(grep('^\\s*\\\\newtheorem\\{theorem\\}', head(x, i))) == 0) {
+    theorem_label = vapply(
+      lapply(theorem_abbr, label_prefix),
+      function(fun) fun(), character(1), USE.NAMES = FALSE)
     theorem_defs = sprintf(
-      '%s\\newtheorem{%s}{%s}%s', theorem_style(names(theorem_abbr)), names(theorem_abbr),
-      str_trim(vapply(theorem_abbr, label_prefix, character(1), USE.NAMES = FALSE)),
+      '%s\\newtheorem{%s}{%s}%s',
+      theorem_style(names(theorem_abbr)),
+      names(theorem_abbr),
+      str_trim(theorem_label),
       if (global) '' else {
         if (length(grep('^\\\\chapter[*]?', x))) '[chapter]' else '[section]'
       }
     )
     # the proof environment has already been defined by amsthm
     proof_envs = setdiff(names(label_names_math2), 'proof')
+    proof_labels = vapply(
+      lapply(proof_envs, label_prefix, dict = label_names_math2),
+      function(fun) fun(), character(1), USE.NAMES = FALSE)
     proof_defs = sprintf(
       '%s\\newtheorem*{%s}{%s}', theorem_style(proof_envs), proof_envs,
-      gsub('^\\s+|[.]\\s*$', '', vapply(proof_envs, label_prefix, character(1), label_names_math2))
+      gsub('^\\s+|[.]\\s*$', '', proof_labels)
     )
     x = append(x, c('\\usepackage{amsthm}', theorem_defs, proof_defs), i - 1)
   }

--- a/R/latex.R
+++ b/R/latex.R
@@ -234,9 +234,9 @@ restore_block2 = function(x, global = FALSE) {
   # fenced div (\begin) is used
   if (length(grep(sprintf('^\\\\(BeginKnitrBlock|begin)\\{(%s)\\}', paste(all_math_env, collapse = '|')), x)) &&
       length(grep('^\\s*\\\\newtheorem\\{theorem\\}', head(x, i))) == 0) {
-    theorem_label = vapply(
-      lapply(theorem_abbr, label_prefix),
-      function(fun) fun(), character(1), USE.NAMES = FALSE)
+    theorem_label = vapply(theorem_abbr, function(a) {
+      label_prefix(a)()
+    }, character(1), USE.NAMES = FALSE)
     theorem_defs = sprintf(
       '%s\\newtheorem{%s}{%s}%s', theorem_style(names(theorem_abbr)),
       names(theorem_abbr), str_trim(theorem_label),

--- a/R/utils.R
+++ b/R/utils.R
@@ -505,7 +505,7 @@ eng_proof = function(options) {
     "The type of proof '", type, "' is not supported yet."
   )
   options$type = type
-  label = label_prefix(type, label_names_math2)
+  label = label_prefix(type, label_names_math2)()
   name = options$name; to_md = output_md()
   if (length(name) == 1) {
     if (!to_md) options$latex.options = sprintf('[%s]', sub('[.]\\s*$', '', name))

--- a/inst/examples/04-customization.Rmd
+++ b/inst/examples/04-customization.Rmd
@@ -245,6 +245,16 @@ language:
     fig: "FIGURE "
 ```
 
-The fields under `ui` are used to specify some terms in the user interface. The `edit` field specifies the text associated with the `edit` link in `_bookdown.yml` (Section \@ref(configuration)). The `chapter_name` field can be either a character string to be prepended to chapter numbers in chapter titles (e.g., `'CHAPTER '`), or an R function that takes the chapter number as the input and returns a string as the new chapter number (e.g., `!expr function(i) paste('Chapter', i)`). If it is a character vector of length 2, the chapter title prefix will be `paste0(chapter_name[1], i, chapter_name[2])`, where `i` is the chapter number. Similarly, the `appendix_name` field will be prepended to appendix counters in appendix titles (e.g., `'Appendix '`). Again, a function can also be used.
+The fields under `ui` are used to specify some terms in the user interface. The `edit` field specifies the text associated with the `edit` link in `_bookdown.yml` (Section \@ref(configuration)). The fields `chapter_name`, `appendix_name`, `fig`, `tab` and `eq` can be either a character string to be prepended to chapter (e.g., `'CHAPTER '`) or reference number (e.g., `'FIGURE '`), or an R function that takes a number (chapter or reference number) as the input and returns a string. (e.g., `!expr function(i) paste('Chapter', i)`). Here is an example for Hungarian:
+
+```yaml
+language:
+  label:
+    fig: !expr function(i) paste(i, 'ábra')
+  ui:
+    chapter_name: !expr function(i) paste0(i, '. fejezet')
+```
+
+For `chapter_name` and `appendix_name` only, if it is a character vector of length 2, the chapter title prefix will be `paste0(chapter_name[1], i, chapter_name[2])`, where `i` is the chapter number.
 
 There is one caveat when you write in a language that uses multibyte characters, such as Chinese, Japanese, and Korean (CJK): Pandoc cannot generate identifiers from section headings that are pure CJK characters, so you will not be able to cross-reference sections (they do not have labels), unless you manually assign identifiers to them by appending `{#identifier}` to the section heading, where `identifier` is an identifier of your choice.

--- a/tests/testit/test-html.R
+++ b/tests/testit/test-html.R
@@ -32,3 +32,29 @@ assert("biblio references section is correcly found", {
   (parse_references(html)$div %==% html[[4]])
   (length(parse_references(html)$refs) == 1)
 })
+
+assert("i18n config can be retrieved ", {
+  opts$set(config = list())
+  # default
+  (i18n("label", "tab", label_names) %==% "Table ")
+  (i18n("ui", "chapter_name", ui_names) %==% "")
+  (i18n("ui", "dummy", ui_names) %==% NULL)
+  # config set
+  opts$set(config = list(language = list(
+    label = list(tab = "TABLE "),
+    ui = list(chapter_name = "CHAPTER "))
+  ))
+  (i18n("label", "tab") %==% "TABLE ")
+  (i18n("ui", "chapter_name") %==% "CHAPTER ")
+  opts$set(config = list())
+})
+
+assert("label_prefix retrieves correct config", {
+  fun = function(i) paste0("TAB-", i)
+  opts$set(config = list(language = list(label = list(tab = fun))))
+  (label_prefix("tab") %==% fun)
+  (is.function(label_prefix("fig")))
+  (label_prefix("fig")(1) %==% "Figure 1")
+  (label_prefix("fig", sep = ":")(1) %==% "Figure 1:")
+  opts$set(config = list())
+})


### PR DESCRIPTION
This will solves #1114 

For now I only added support for `fig`, `eq` and `tab`. Support for theorem or proof env is a bit trickier because `label_prefix` is used for find the label to use for `\newtheorem` in `preamble` where number is not used
https://github.com/rstudio/bookdown/blob/cec8efb9cc695d4c8e873f828abe9e171bd5d50e/R/latex.R#L239
and for proof env too
https://github.com/rstudio/bookdown/blob/cec8efb9cc695d4c8e873f828abe9e171bd5d50e/R/latex.R#L248


This means it can't be a function of reference number, and case is different between LaTeX and non LaTeX. 
I wanted to support all because for non LaTeX output this is the same mechanism: label is prepended by default. However, I did not find an easy way to do it because of the constraint mention above. But also I am not sure that what I have done currently is a lot easier. 

@yihui you may want to review that more closely in case you see a way to also allow the use of a function for all `theorem_abbr` and `label_names_math2`. 
