### PR TITLE
Allow the knit button to work in subdirs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 - In `_bookdown.yaml`, `label` fields `fig`, `tab` and `eq` can now take a function as `ui` fields `chapter_name` and `appendix`. This function takes the reference number as only argument and must return a character to be used as full label. The default is a string prepended before the reference number. This new feature gives more flexibility to change the default for other language, e.g append the label name after the number. See updated doc about [Internationalization](https://bookdown.org/yihui/bookdown/internationalization.html)(thanks, Tamás Ferenc, #1114)
 
+- Using the 'Knit' button now also works with a Rmd file in a sub-directory of the book project (when `rmd_subdir` is used in `_bookdown.yml`) (#1122)
+
 ## BUG FIXES
 
 - Adapt CSS in `gitbook()` and `html_book()` for correct diplaying of `<details><summary>` content (thanks, @maelle, #971)

--- a/R/site.R
+++ b/R/site.R
@@ -35,15 +35,12 @@ bookdown_site = function(input, ...) {
       in_dir(input, render_book_script(output_format, envir, quiet))
     } else {
       # Input file can be in a subdirectory  of the project. So we need to catch the
-      # message "\Output created: " emitted by render() used by RStudio to preview the html result
-      # to modify it from relative to absolute.
-      msg_render = NULL
-      r = '^\nOutput created: '
+      # message "\Output created: " emitted by render() used by RStudio, and muffle it
+      # to emit our own
       res = withCallingHandlers(
         message = function(e) {
-          if (grepl(r, e$message)) {
-            # capture and save the message here, then muffle it
-            msg_render <<- e$message
+          if (grepl('^\nOutput created: ', e$message)) {
+            # muffle the message
             invokeRestart("muffleMessage")
           }
         },
@@ -52,11 +49,7 @@ bookdown_site = function(input, ...) {
           render_book(input_file, output_format, envir = envir, preview = TRUE)
         )
       )
-      if (!is.null(msg_render)) {
-        path <- gsub(r, "", msg_render)
-        # capture and save the message here, then muffle it
-        message(paste0("\nOutput created: ", file.path(book_proj, path)))
-      }
+      if (!quiet) message(paste0("\nOutput created: ", res))
       res
     }
   }

--- a/R/site.R
+++ b/R/site.R
@@ -46,6 +46,7 @@ bookdown_site = function(input, ...) {
     name = name,
     output_dir = book_dir,
     render = render,
+    subdirs = TRUE,
     clean = clean
   )
 }

--- a/R/site.R
+++ b/R/site.R
@@ -34,21 +34,15 @@ bookdown_site = function(input, ...) {
     if (is.null(input_file)) {
       in_dir(input, render_book_script(output_format, envir, quiet))
     } else {
-      # Input file can be in a subdirectory  of the project. So we need to catch the
-      # message "\Output created: " emitted by render() used by RStudio, and muffle it
-      # to emit our own
-      res = withCallingHandlers(
-        message = function(e) {
-          if (grepl('^\nOutput created: ', e$message)) {
-            # muffle the message
-            invokeRestart("muffleMessage")
-          }
-        },
-        xfun::in_dir(
+      # Input file can be in a sub-directory  of the project. So we need to
+      # to emit our own message with absolute path
+      res = xfun::in_dir(
           book_proj,
-          render_book(input_file, output_format, envir = envir, preview = TRUE)
-        )
+          suppress_output_message(
+            render_book(input_file, output_format, envir = envir, preview = TRUE)
+          )
       )
+      # emit our own message for IDE preview
       if (!quiet) message(paste0("\nOutput created: ", res))
       res
     }
@@ -97,4 +91,18 @@ find_book_proj = function(input) {
     '^index.Rmd$', '^\\s*site:\\s*bookdown::bookdown_site\\s*$'
   ), ncol = 2, byrow = TRUE, dimnames = list(NULL, c('file', 'pattern')))
   xfun::proj_root(input, rules)
+}
+
+# This function aims at suppressing the message "\nOutput created: <path>" emitted by render()
+# and used by RStudio to preview, so that another one can be emitted
+suppress_output_message <- function(expr, pattern = '^\nOutput created: ') {
+  withCallingHandlers(
+    expr,
+    message = function(e) {
+      if (grepl(pattern, e$message)) {
+        # muffle the message
+        invokeRestart("muffleMessage")
+      }
+    }
+  )
 }

--- a/tests/testit/test-site.R
+++ b/tests/testit/test-site.R
@@ -1,0 +1,8 @@
+library(testit)
+
+assert("suppress_output_message works as expected", {
+  catch = function(expr) tryCatch(expr, message = function(e) e$message)
+  (catch(suppress_output_message(message("a"))) %==% "a\n")
+  (catch(suppress_output_message(message("\nOutput created: "))) %==% NULL)
+  (catch(suppress_output_message(message("a"), "^a")) %==% NULL)
+})


### PR DESCRIPTION
fixes #1121 

It is like with **blogdown**, with this adjustment a Rmd file in a subdir can be previewed using the knit button. 

Only issue is that RStudio IDE won't open the preview because 

* `rmarkdown::render()` returns a relative path e.g `_book/02-litterature.html` to the bookdown project
* RStudio IDE consider a relative path as being relative to the input file - which in this case is not because the Rmd file is in a sub directory. 

Rmarkdown website deals with that by suppressing message for `render()` to avoid `Output created:` to be written by `render` in console and throw itself the message with `render_site()` - this happens in `default_site()`. 

I tried adding one message in `render=` inside `bookdown_site()` but as `render()` already emits one, only the first is taken into account it seems.

We could do the same in **bookdown** but it seems a bit too much to suppress message from `render()` completly. 
What about a new option to introduce in **rmarkdown** that would allow us to deactivate the printing of this message in `render()` from other package ? 

@yihui what do you think we could do ? 

I put as draft so that we decide what to do, but it seems making the Knit button work for a bookdown project is important. I recognize that using subdirs and preview may not be a lot of cases.
 