### PR TITLE
Allow to generate epub  book version 2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN bookdown VERSION 0.23
 
+- `epub_version` argument in `epub_book()` can now be set to `epub2` to creat EPUB book of version 2. This follows an old change for default behavior in Pandoc 2.0 where the alias `epub` defaults to `epub3` and no more `epub2` (thanks, jtbayly, #1150).
+
 - [Theorem and Proof environment](https://bookdown.org/yihui/bookdown/markdown-extensions-by-bookdown.html#theorems) can now be used with `beamer_presentation2()` using fenced Div syntax like this
   ````markdown
   ::: {.theorem #label name="My Theorem"}

--- a/R/ebook.R
+++ b/R/ebook.R
@@ -12,19 +12,21 @@
 #' @param metadata The path to the EPUB metadata file.
 #' @param chapter_level The level by which the e-book is split into separate
 #'   \dQuote{chapter} files.
-#' @param epub_version Whether to use version 3 or 2 of EPUB. \code{"epub"} is
-#'   an alias for \code{"epub3"} since Pandoc 2.0 and \code{"epub2"} for earlier
-#'   version.
+#' @param epub_version Whether to use version 3 or 2 of EPUB. This correspond to
+#'   [Pandoc's supported output
+#'   format](https://pandoc.org/MANUAL.html#option--to). `"epub"` is an alias
+#'   for `"epub3"` since Pandoc 2.0 and `"epub2"` for earlier version.
 #' @param md_extensions A character string of Pandoc Markdown extensions.
 #' @param pandoc_args A vector of additional Pandoc arguments.
-#' @param template Pandoc template to use for rendering. Pass \code{"default"}
+#' @param template Pandoc template to use for rendering. Pass `"default"`
 #'   to use Pandoc's built-in template; pass a path to use a custom template.
 #'   The default pandoc template should be sufficient for most use cases. In
 #'   case you want to develop a custom template, we highly recommend to start
 #'   from the default EPUB templates at
-#'   \url{https://github.com/jgm/pandoc-templates/}.
+#'   <https://github.com/jgm/pandoc-templates/>.
 #' @note Figure/table numbers cannot be generated if sections are not numbered
-#'   (\code{number_sections = FALSE}).
+#'   (`number_sections = FALSE`).
+#' @md
 #' @export
 epub_book = function(
   fig_width = 5, fig_height = 4, dev = 'png', fig_caption = TRUE,

--- a/R/ebook.R
+++ b/R/ebook.R
@@ -12,7 +12,9 @@
 #' @param metadata The path to the EPUB metadata file.
 #' @param chapter_level The level by which the e-book is split into separate
 #'   \dQuote{chapter} files.
-#' @param epub_version Whether to use version 3 or 2 of EPUB.
+#' @param epub_version Whether to use version 3 or 2 of EPUB. \code{"epub"} is
+#'   an alias for \code{"epub3"} since Pandoc 2.0 and \code{"epub2"} for earlier
+#'   version.
 #' @param md_extensions A character string of Pandoc Markdown extensions.
 #' @param pandoc_args A vector of additional Pandoc arguments.
 #' @param template Pandoc template to use for rendering. Pass \code{"default"}
@@ -28,7 +30,7 @@ epub_book = function(
   fig_width = 5, fig_height = 4, dev = 'png', fig_caption = TRUE,
   number_sections = TRUE, toc = FALSE, toc_depth = 3, stylesheet = NULL,
   cover_image = NULL, metadata = NULL, chapter_level = 1,
-  epub_version = c('epub3', 'epub'), md_extensions = NULL, pandoc_args = NULL,
+  epub_version = c('epub3', 'epub', 'epub2'), md_extensions = NULL, pandoc_args = NULL,
   template = 'default'
 ) {
   epub_version = match.arg(epub_version)

--- a/man/epub_book.Rd
+++ b/man/epub_book.Rd
@@ -16,7 +16,7 @@ epub_book(
   cover_image = NULL,
   metadata = NULL,
   chapter_level = 1,
-  epub_version = c("epub3", "epub"),
+  epub_version = c("epub3", "epub", "epub2"),
   md_extensions = NULL,
   pandoc_args = NULL,
   template = "default"
@@ -40,7 +40,9 @@ applied to the eBook.}
 \item{chapter_level}{The level by which the e-book is split into separate
 \dQuote{chapter} files.}
 
-\item{epub_version}{Whether to use version 3 or 2 of EPUB.}
+\item{epub_version}{Whether to use version 3 or 2 of EPUB. This correspond to
+\href{https://pandoc.org/MANUAL.html#option--to}{Pandoc's supported output format}. \code{"epub"} is an alias
+for \code{"epub3"} since Pandoc 2.0 and \code{"epub2"} for earlier version.}
 
 \item{md_extensions}{A character string of Pandoc Markdown extensions.}
 
@@ -59,5 +61,5 @@ many readers, such as Amazon Kindle Fire and iBooks on Apple devices.
 }
 \note{
 Figure/table numbers cannot be generated if sections are not numbered
-  (\code{number_sections = FALSE}).
+(\code{number_sections = FALSE}).
 }


### PR DESCRIPTION
This fix #1150 

**bookdown** did not follow the change in Pandoc 2 regarding the default value for alias epub