### PR TITLE
Fix error in render_book() example

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -44,7 +44,7 @@
 #' # will use the default format defined in index.Rmd or _output.yml
 #' bookdown::render_book("index.Rmd")
 #' # will use the options for format defined in YAML metadata
-#' bookdown::render_book("index.Rmd",  "pdf_book")
+#' bookdown::render_book("index.Rmd",  "bookdown::pdf_book")
 #' # If you pass an output format object, it must have all the options set
 #' bookdown::render_book("index.Rmd", bookdown::pdf_book(toc = FALSE))
 #'

--- a/man/render_book.Rd
+++ b/man/render_book.Rd
@@ -74,7 +74,7 @@ if (file.exists("index.Rmd")) bookdown::render_book("index.Rmd")
 # will use the default format defined in index.Rmd or _output.yml
 bookdown::render_book("index.Rmd")
 # will use the options for format defined in YAML metadata
-bookdown::render_book("index.Rmd", "pdf_book")
+bookdown::render_book("index.Rmd", "bookdown::pdf_book")
 # If you pass an output format object, it must have all the options set
 bookdown::render_book("index.Rmd", bookdown::pdf_book(toc = FALSE))
 


### PR DESCRIPTION
`render_book("index.Rmd",  "pdf_book")` gives an error when ran. According to https://bookdown.org/yihui/rmarkdown/output-formats.html and rstudio/bookdown#585 the output format must specify the bookdown package, which does run correctly.