### PR TITLE
Add display block CSS to figure anchor span

### DIFF
--- a/R/html.R
+++ b/R/html.R
@@ -665,7 +665,7 @@ parse_fig_labels = function(content, global = FALSE) {
       }
       labs[[i]] = label_prefix(type, sep = ': ')(num)
       k = max(figs[figs <= i])
-      content[k] = paste(c(content[k], sprintf('<span id="%s"></span>', lab)), collapse = '')
+      content[k] = paste(c(content[k], sprintf('<span style="display:block;" id="%s"></span>', lab)), collapse = '')
     }, tab = {
       if (length(grep('^\\s*<caption', content[i - 0:1])) == 0) next
       labs[[i]] = sprintf(


### PR DESCRIPTION
This fixes #1155 

It seems this is required so that the anchor span stays correctly right after the div of class figure. 

@yihui do you have previous experience with this ? 

## tested with 

The link correctly send to the top of the header

````markdown
---
title: "book"
output: 
  bookdown::html_document2: default
---

```{r, echo = FALSE, results='asis'}
cat(stringi::stri_rand_lipsum("10"), sep = "\n\n")
```

```{r fig1, fig.cap = "hello"}
plot(mtcars)
```

See \@ref(fig:fig1)

```{r, echo = FALSE, results='asis'}
cat(stringi::stri_rand_lipsum("10"), sep = "\n\n")
```
````