### PR TITLE
[DOCS] Add a box about new custom block syntax in the cookbook

### DIFF
--- a/inst/examples/02-components.Rmd
+++ b/inst/examples/02-components.Rmd
@@ -596,6 +596,10 @@ Cross-references still work even when we refer to an item that is not on the cur
 
 ## Custom blocks
 
+:::{.rmdimportant latex=true}
+A new syntax is now adviced to create custom blocks. We invite you to refer to [Chapter 9.6 in the R Markdown Cookbook](https://bookdown.org/yihui/rmarkdown-cookbook/custom-blocks.html) [@rmarkdown2020] and no more use the `block` and `block2` engine described below. Those will be deprecated in future version of **bookdown**. Please make the change in your content if you are still using one of this engine directly.
+:::
+
 You can generate custom blocks\index{custom block} using the `block` engine in **knitr**, i.e., the chunk option `engine = 'block'`, or the more compact syntax ```` ```{block} ````. This engine should be used in conjunction with the chunk option `type`, which takes a character string. When the `block` engine is used, it generates a `<div>` to wrap the chunk content if the output format is HTML, and a LaTeX environment if the output is LaTeX. The `type` option specifies the class of the `<div>` and the name of the LaTeX environment. For example, the HTML output of this chunk
 
 ````markdown


### PR DESCRIPTION
This close #939 (I used the incorrect number in other PR #1173)

I thought about this and decided that it was not a good idea to re-document custom block in this book. It would be a duplication in two places. 

So I added a box to mention that the `block` and `bloc2` engine are no more to be used and one should look at the R Markdown Cookbook

Is that enough ? 

We could later just remove this chapter from **bookdown** for a second edition as there would not be any specificity. 

