### PR TITLE
`bs4_book()`: Make math work in footnotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bookdown
 Type: Package
 Title: Authoring Books and Technical Documents with R Markdown
-Version: 0.22.5
+Version: 0.22.6
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("JJ", "Allaire", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN bookdown VERSION 0.23
 
+- In `bs4_book`, math in footnotes is now rendered (@mine-cetinkaya-rundel, #1026)
+
 - Figure reference links now point correctly to the top of figures (thanks, @GuillaumeBiessy, #1155).
 
 - `epub_version` argument in `epub_book()` can now be set to `epub2` to creat EPUB book of version 2. This follows an old change for default behavior in Pandoc 2.0 where the alias `epub` defaults to `epub3` and no more `epub2` (thanks, jtbayly, #1150).

--- a/R/bs4_book.R
+++ b/R/bs4_book.R
@@ -316,7 +316,7 @@ tweak_footnotes <- function(html) {
   id <- xml2::xml_attr(footnotes, "id")
   xml2::xml_remove(xml2::xml_find_all(footnotes, "//a[@class='footnote-back']"))
   contents <- vapply(footnotes, FUN.VALUE = character(1), function(x) {
-    as.character(xml2::xml_children(x))
+    paste0(as.character(xml2::xml_children(x)), collapse = "")
   })
 
   # Add popover attributes to links

--- a/inst/templates/bs4_book.html
+++ b/inst/templates/bs4_book.html
@@ -108,24 +108,6 @@ $endfor$
 
 
 $if(math)$
-<script type="text/x-mathjax-config">
-const popovers = document.querySelectorAll('a.footnote-ref[data-toggle="popover"]');
-for (let popover of popovers){
-  const div = document.createElement('div');
-  div.setAttribute('style', 'position: absolute; top: 0, left:0; width:0, height:0, overflow: hidden; visibility: hidden;');
-  div.innerHTML = popover.getAttribute('data-content');
-
-  // Will this work with TeX on its own line?
-  var has_math = div.querySelector("span.math");
-  if (has_math) {
-    document.body.appendChild(div);
-  	MathJax.Hub.Queue(["Typeset", MathJax.Hub, div]);
-  	MathJax.Hub.Queue(function(){
-      popover.setAttribute('data-content', div.innerHTML);
-  	})
-  }
-}
-</script>
 <!-- dynamically load mathjax for compatibility with self-contained -->
 <script>
   (function () {

--- a/inst/templates/bs4_book.html
+++ b/inst/templates/bs4_book.html
@@ -24,7 +24,7 @@
   $for(css)$
   <link rel="stylesheet" href="$css$" />
   $endfor$
-  
+
 </head>
 
 <body data-spy="scroll" data-target="#toc">
@@ -108,6 +108,24 @@ $endfor$
 
 
 $if(math)$
+<script type="text/x-mathjax-config">
+const popovers = document.querySelectorAll('a.footnote-ref[data-toggle="popover"]');
+for (let popover of popovers){
+  const div = document.createElement('div');
+  div.setAttribute('style', 'position: absolute; top: 0, left:0; width:0, height:0, overflow: hidden; visibility: hidden;');
+  div.innerHTML = popover.getAttribute('data-content');
+
+  // Will this work with TeX on its own line?
+  var has_math = div.querySelector("span.math");
+  if (has_math) {
+    document.body.appendChild(div);
+  	MathJax.Hub.Queue(["Typeset", MathJax.Hub, div]);
+  	MathJax.Hub.Queue(function(){
+      popover.setAttribute('data-content', div.innerHTML);
+  	})
+  }
+}
+</script>
 <!-- dynamically load mathjax for compatibility with self-contained -->
 <script>
   (function () {
@@ -121,6 +139,25 @@ $if(math)$
     script.src = src;
     document.getElementsByTagName("head")[0].appendChild(script);
   })();
+</script>
+<!-- https://stackoverflow.com/a/49687594 -->
+<script type="text/x-mathjax-config">
+const popovers = document.querySelectorAll('a.footnote-ref[data-toggle="popover"]');
+for (let popover of popovers){
+  const div = document.createElement('div');
+  div.setAttribute('style', 'position: absolute; top: 0, left:0; width:0, height:0, overflow: hidden; visibility: hidden;');
+  div.innerHTML = popover.getAttribute('data-content');
+
+  // Will this work with TeX on its own line?
+  var has_math = div.querySelector("span.math");
+  if (has_math) {
+    document.body.appendChild(div);
+  	MathJax.Hub.Queue(["Typeset", MathJax.Hub, div]);
+  	MathJax.Hub.Queue(function(){
+      popover.setAttribute('data-content', div.innerHTML);
+  	})
+  }
+}
 </script>
 $endif$
 </body>

--- a/inst/templates/bs4_book.html
+++ b/inst/templates/bs4_book.html
@@ -123,22 +123,20 @@ $if(math)$
   })();
 </script>
 <!-- https://stackoverflow.com/a/49687594 -->
-<script type="text/x-mathjax-config">
-const popovers = document.querySelectorAll('a.footnote-ref[data-toggle="popover"]');
-for (let popover of popovers){
+<script type="text/x-mathjax-config">const popovers = document.querySelectorAll('a.footnote-ref[data-toggle="popover"]');
+for (let popover of popovers) {
   const div = document.createElement('div');
   div.setAttribute('style', 'position: absolute; top: 0, left:0; width:0, height:0, overflow: hidden; visibility: hidden;');
   div.innerHTML = popover.getAttribute('data-content');
 
-  // Will this work with TeX on its own line?
   var has_math = div.querySelector("span.math");
   if (has_math) {
     document.body.appendChild(div);
-  	MathJax.Hub.Queue(["Typeset", MathJax.Hub, div]);
-  	MathJax.Hub.Queue(function(){
+    MathJax.Hub.Queue(["Typeset", MathJax.Hub, div]);
+    MathJax.Hub.Queue(function() {
       popover.setAttribute('data-content', div.innerHTML);
       document.body.removeChild(div);
-  	})
+    })
   }
 }
 </script>

--- a/inst/templates/bs4_book.html
+++ b/inst/templates/bs4_book.html
@@ -137,6 +137,7 @@ for (let popover of popovers){
   	MathJax.Hub.Queue(["Typeset", MathJax.Hub, div]);
   	MathJax.Hub.Queue(function(){
       popover.setAttribute('data-content', div.innerHTML);
+      document.body.removeChild(div);
   	})
   }
 }

--- a/inst/templates/bs4_book.html
+++ b/inst/templates/bs4_book.html
@@ -122,7 +122,6 @@ $if(math)$
     document.getElementsByTagName("head")[0].appendChild(script);
   })();
 </script>
-<!-- https://stackoverflow.com/a/49687594 -->
 <script type="text/x-mathjax-config">const popovers = document.querySelectorAll('a.footnote-ref[data-toggle="popover"]');
 for (let popover of popovers) {
   const div = document.createElement('div');


### PR DESCRIPTION
Fix #1026

Well, unless there's a way to have math paragraphs in footnotes (since I didn't find a way to add those, I didn't test their rendering).