### PR TITLE
bs4_book: no scroll on x overflow and correct copy btn placement

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bookdown
 Type: Package
 Title: Authoring Books and Technical Documents with R Markdown
-Version: 0.22.10
+Version: 0.22.11
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("JJ", "Allaire", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 - In `bs4_book()`, improvement regarding copy button:
   * It has now a light icon instead of a text with white background (#1192). 
   * It will no more show on output block code when knitr's option is `collapse = FALSE` (#1197).
+  * For code block with very long line, it will now wrap in the code block with no more x-scroll bar, and it will wraps around the copy button icon so that text is not hidden (#1187). 
+  If you want to customize part of the UI to change this default behavior, you can do it using a custom css with `bs4_book()`.
 
 - Fix an issue with `bs4_book()` where text written using [Line Block](https://bookdown.org/yihui/rmarkdown-cookbook/indent-text.html) was not found in search (thanks, @dmklotz, #1141).
 

--- a/inst/resources/bs4_book/bs4_book.css
+++ b/inst/resources/bs4_book/bs4_book.css
@@ -396,9 +396,7 @@ code a:any-link {
 /* copy button */
 
 pre .copy {
-float: right;
-margin-left: 1rem;
-margin-bottom: 1rem;
+  float: right;
 }
 
 pre .copy button {

--- a/inst/resources/bs4_book/bs4_book.css
+++ b/inst/resources/bs4_book/bs4_book.css
@@ -378,8 +378,9 @@ code {
 
 pre code {
   background-color: transparent;
-  word-break: normal; /* force wide blocks to scroll, not wrap */
-  word-wrap: normal;
+  white-space: pre-wrap;
+  word-break: break-all;
+  overflow-wrap: break-word;
 }
 
 pre, code {

--- a/inst/resources/bs4_book/bs4_book.css
+++ b/inst/resources/bs4_book/bs4_book.css
@@ -394,9 +394,9 @@ code a:any-link {
 }
 
 pre .copy {
-  position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
+float: right;
+margin-left: 1rem;
+margin-bottom: 1rem;
 }
 pre .copy button {
   background-color: #fff;

--- a/inst/resources/bs4_book/bs4_book.js
+++ b/inst/resources/bs4_book/bs4_book.js
@@ -121,6 +121,7 @@ $(document).ready(function() {
 
     clipboard.on('success', function(e) {
       const btn = e.trigger;
+      changeTooltipMessage(btn, 'Copied!');
       btn.classList.add('btn-copy-checked');
       setTimeout(function() {
         btn.classList.remove('btn-copy-checked');

--- a/inst/resources/bs4_book/bs4_book.js
+++ b/inst/resources/bs4_book/bs4_book.js
@@ -115,7 +115,7 @@ $(document).ready(function() {
     // Initialize clipboard:
     var clipboard = new ClipboardJS('.btn-copy', {
       text: function(trigger) {
-        return trigger.parentNode.previousSibling.textContent;
+        return trigger.parentNode.nextSibling.textContent;
       }
     });
 

--- a/inst/resources/bs4_book/bs4_book.js
+++ b/inst/resources/bs4_book/bs4_book.js
@@ -108,7 +108,7 @@ $(document).ready(function() {
   if(ClipboardJS.isSupported()) {
     // Insert copy buttons
     var copyButton = "<div class='copy'><button type='button' class='btn btn-outline-primary btn-copy' title='Copy to clipboard' aria-label='Copy to clipboard' data-toggle='popover' data-placement='top' data-trigger='hover'>Copy</button></div>";
-    $(copyButton).appendTo("pre");
+    $(copyButton).prependTo("pre");
     // Initialize tooltips:
     $('.btn-copy').tooltip({container: 'body', boundary: 'window'});
 


### PR DESCRIPTION
Fix #1086

Also related #1040 (currently the copy-code button might _hide_ some code)