### PR TITLE
indented text should be part of search data for fuse.js in bs4_book

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bookdown
 Type: Package
 Title: Authoring Books and Technical Documents with R Markdown
-Version: 0.22.8
+Version: 0.22.9
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("JJ", "Allaire", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN bookdown VERSION 0.23
 
+- Fix an issue with `bs4_book()` where text written using [Line Block](https://bookdown.org/yihui/rmarkdown-cookbook/indent-text.html) was not found in search (thanks, @dmklotz, #1141).
+
 - `bs4_book()` has now some `<meta>` tags that allows sharing a published book on social media. `cover-image`, `url`, `title` and `description` set in YAML will be used in `index.html` and then modified to be adapted per HTML page (#1034). 
 
 - Style change in `bs4_book()` where code block inside callout blocks will have their background fill the whole width of the bordered block (#1175).

--- a/R/bs4_book.R
+++ b/R/bs4_book.R
@@ -712,7 +712,7 @@ bs4_index_data <- function(node, chapter, path) {
   }
 
   all <- function(...) paste0("descendant-or-self::", c(...), collapse = "|")
-  text_path <- all("p", "li", "caption", "figcaption", "dt", "dd")
+  text_path <- all("p", "li", "caption", "figcaption", "dt", "dd", "div[contains(@class, 'line-block')]")
   code_path <- all("pre")
 
   code <- xml2::xml_find_all(children, code_path)


### PR DESCRIPTION
Following part of the fix in https://github.com/r-lib/pkgdown/pull/1629/commits/3f4623f88b7e2f4f2a4c1fae61c30ccc88563ec7

This fix #1141

Issue was that indented text per https://bookdown.org/yihui/rmarkdown-cookbook/indent-text.html using Pandoc syntax Line Block (https://pandoc.org/MANUAL.html#line-blocks) have no `<p>` tag inside the `div` of class `line-block` created. We need to retrieve that explicitly

Tested in cderv/bs4booktesting repo