### PR TITLE
Support comment after site: key in YAML header for index.Rmd

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bookdown
 Type: Package
 Title: Authoring Books and Technical Documents with R Markdown
-Version: 0.22.9
+Version: 0.22.10
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("JJ", "Allaire", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,8 @@
 
   Depending on user feedback, we may set `fuse` to be the default search engine in a future version of **bookdown**. We will appreciate your testing and feedback!
 
+- Fix an issue with `bookdown_site()` where the comment in `site:` line key was not supported (thanks, @LDSamson, #1194).
+
 - Figure reference links now point correctly to the top of figures (thanks, @GuillaumeBiessy, #1155).
 
 - `epub_version` argument in `epub_book()` can now be set to `epub2` to creat EPUB book of version 2. This follows an old change for default behavior in Pandoc 2.0 where the alias `epub` defaults to `epub3` and no more `epub2` (thanks, jtbayly, #1150).

--- a/R/site.R
+++ b/R/site.R
@@ -86,7 +86,7 @@ find_book_name = function(config, default) {
 find_book_proj = function(input) {
   # if bookdown_site() is executed it is because site: has been set in index.Rmd
   rules = matrix(c(
-    '^index.Rmd$', '^\\s*site:\\s*["\']?bookdown::bookdown_site["\']?\\s*$'
+    '^index.Rmd$', '^\\s*site:\\s*["\']?bookdown::bookdown_site["\']?\\s*(?:#.*)?$'
   ), ncol = 2, byrow = TRUE, dimnames = list(NULL, c('file', 'pattern')))
   xfun::proj_root(input, rules)
 }

--- a/tests/testthat/helper-bs4_book.R
+++ b/tests/testthat/helper-bs4_book.R
@@ -17,24 +17,8 @@ local_bs4_book <- function(name = "book",
   # don't run test using this book skeleton when Pandoc is not available
   skip_if_not_pandoc()
 
-  path <- withr::local_tempdir(.local_envir = env)
-
-  book_skeleton(
-    name = name,
-    title = title,
-    author = author,
-    path = path,
-    description = description,
-    url = url
-  )
-
-  # Add text to Introduction
-
-  intro <- readLines(file.path(path, "01-Introduction.Rmd"))
-  writeLines(
-    c(intro, paste0(rep(0:9, 42), collapse = " ")),
-    file.path(path, "01-Introduction.Rmd")
-  )
+  path <- local_book(name = name, title = title, author = author,
+    description = description, url = url, verbose = verbose, env = env)
 
   suppressMessages(
     render_book(

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -23,3 +23,34 @@ skip_if_pandoc <- function(ver = NULL) {
     skip(msg)
   }
 }
+
+
+local_book <- function(name = "book",
+                       title = "Awesome Cookbook",
+                       author = "Yoda",
+                       description = NULL,
+                       url = NULL,
+                       verbose = FALSE,
+                       env = parent.frame()) {
+
+  path <- withr::local_tempdir(.local_envir = env)
+
+  book_skeleton(
+    name = name,
+    title = title,
+    author = author,
+    path = path,
+    description = description,
+    url = url
+  )
+
+  # Add text to Introduction
+
+  intro <- readLines(file.path(path, "01-Introduction.Rmd"))
+  writeLines(
+    c(intro, paste0(rep(0:9, 42), collapse = " ")),
+    file.path(path, "01-Introduction.Rmd")
+  )
+
+  return(path)
+}

--- a/tests/testthat/test-site.R
+++ b/tests/testthat/test-site.R
@@ -1,0 +1,9 @@
+test_that("find_book_proj() correction found the root dir", {
+  book_dir <- local_book()
+  withr::local_dir(book_dir)
+  expect_equal(normalizePath(find_book_proj(".")), book_dir)
+  expect_equal(normalizePath(find_book_proj("01-Introduction.Rmd")), book_dir)
+  gsub("^(site:.*)$", "\\1 # any comment", xfun::read_utf8("index.Rmd"))
+  xfun::gsub_file("index.Rmd", pattern = "^(site:.*)$", replacement = "\\1 # any comment")
+  expect_equal(normalizePath(find_book_proj(".")), book_dir)
+})


### PR DESCRIPTION
fix #1194 

This just take into account possible comment at the end of the `site:` key line, and it adds some tests using testthat infra