### PR TITLE
normalize path for comparaison in test

### DIFF
--- a/tests/testthat/test-site.R
+++ b/tests/testthat/test-site.R
@@ -5,5 +5,5 @@ test_that("find_book_proj() correction found the root dir", {
   expect_equal(normalizePath(find_book_proj("01-Introduction.Rmd")), book_dir)
   gsub("^(site:.*)$", "\\1 # any comment", xfun::read_utf8("index.Rmd"))
   xfun::gsub_file("index.Rmd", pattern = "^(site:.*)$", replacement = "\\1 # any comment")
-  expect_equal(normalizePath(find_book_proj(".")), book_dir)
+  expect_equal(normalizePath(find_book_proj(".")), normalizePath(book_dir))
 })

--- a/tests/testthat/test-site.R
+++ b/tests/testthat/test-site.R
@@ -1,9 +1,9 @@
 test_that("find_book_proj() correction found the root dir", {
-  book_dir <- local_book()
+  book_dir <- xfun::normalize_path(local_book())
   withr::local_dir(book_dir)
-  expect_equal(normalizePath(find_book_proj(".")), book_dir)
-  expect_equal(normalizePath(find_book_proj("01-Introduction.Rmd")), book_dir)
+  expect_equal(find_book_proj("."), book_dir)
+  expect_equal(find_book_proj("01-Introduction.Rmd"), book_dir)
   gsub("^(site:.*)$", "\\1 # any comment", xfun::read_utf8("index.Rmd"))
   xfun::gsub_file("index.Rmd", pattern = "^(site:.*)$", replacement = "\\1 # any comment")
-  expect_equal(normalizePath(find_book_proj(".")), normalizePath(book_dir))
+  expect_equal(find_book_proj("."), book_dir)
 })


### PR DESCRIPTION
Fix CI failure following afadf50. 

it seems a test working locally on Windows is not the same as in WINDOWS builder in GHA.