### PR TITLE
only apply button to source code block

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # CHANGES IN bookdown VERSION 0.23
 
-- In `bs4_book()`, copy button has now a light icon instead of a text with white background (#1192). 
+- In `bs4_book()`, improvement regarding copy button:
+  * It has now a light icon instead of a text with white background (#1192). 
+  * It will no more show on output block code when knitr's option is `collapse = FALSE` (#1197).
 
 - Fix an issue with `bs4_book()` where text written using [Line Block](https://bookdown.org/yihui/rmarkdown-cookbook/indent-text.html) was not found in search (thanks, @dmklotz, #1141).
 

--- a/inst/resources/bs4_book/bs4_book.js
+++ b/inst/resources/bs4_book/bs4_book.js
@@ -108,7 +108,7 @@ $(document).ready(function() {
   if(ClipboardJS.isSupported()) {
     // Insert copy buttons
     var copyButton = "<div class='copy'><button type='button' class='btn btn-copy' title='Copy to clipboard' aria-label='Copy to clipboard' data-toggle='popover' data-placement='top' data-trigger='hover'><i class='bi'></i></button></div>";
-    $(copyButton).appendTo("pre");
+    $(copyButton).appendTo("pre.sourceCode");
     // Initialize tooltips:
     $('.btn-copy').tooltip({container: 'body', boundary: 'window'});
 


### PR DESCRIPTION
This offer support for `collapse = FALSE` and deal with one of the feedback from #1040

This is also the behavior from `gitbook()`

Testing site: https://cderv.github.io/bs4booktesting/nocopybuttononoutput/#collapse-true-vs-false

Must follow #1187 that should be merged into master then this branch updated


