### PR TITLE
Revert and improve change on code block regarding scrolling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bookdown
 Type: Package
 Title: Authoring Books and Technical Documents with R Markdown
-Version: 0.22.11
+Version: 0.22.12
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("JJ", "Allaire", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bookdown
 Type: Package
 Title: Authoring Books and Technical Documents with R Markdown
-Version: 0.22.10
+Version: 0.22.11
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("JJ", "Allaire", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bookdown
 Type: Package
 Title: Authoring Books and Technical Documents with R Markdown
-Version: 0.22.11
+Version: 0.22.10
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("JJ", "Allaire", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,6 @@
 - In `bs4_book()`, improvement regarding copy button:
   * It has now a light icon instead of a text with white background (#1192). 
   * It will no more show on output block code when knitr's option is `collapse = FALSE` (#1197).
-  * For code block with very long line, it will now wrap in the code block with no more x-scroll bar, and it will wraps around the copy button icon so that text is not hidden (#1187). 
-  If you want to customize part of the UI to change this default behavior, you can do it using a custom css with `bs4_book()`.
 
 - Fix an issue with `bs4_book()` where text written using [Line Block](https://bookdown.org/yihui/rmarkdown-cookbook/indent-text.html) was not found in search (thanks, @dmklotz, #1141).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 - In `bs4_book()`, improvement regarding copy button:
   * It has now a light icon instead of a text with white background (#1192). 
   * It will no more show on output block code when knitr's option is `collapse = FALSE` (#1197).
+  * It will now be placed correctly on the right side of the code block, with a light color which gets darker on hover so that it is less obtrusive when ovelapping text in block with long lines  (#1204). If you want to customize part of the UI to change this default behavior, you can do it using a custom css with `bs4_book()`.
 
 - Fix an issue with `bs4_book()` where text written using [Line Block](https://bookdown.org/yihui/rmarkdown-cookbook/indent-text.html) was not found in search (thanks, @dmklotz, #1141).
 

--- a/inst/resources/bs4_book/bs4_book.css
+++ b/inst/resources/bs4_book/bs4_book.css
@@ -520,6 +520,11 @@ body {
   padding: 1rem;
 }
 
+.rmdcaution .btn-copy, .rmdimportant .btn-copy, .rmdnote .btn-copy, .rmdtip .btn-copy, .rmdwarning .btn-copy {
+  /* Needs to be set according to margin in callout pre block */
+  right: -1rem;
+}
+
 main ul {
  list-style-type: square;
 }

--- a/inst/resources/bs4_book/bs4_book.css
+++ b/inst/resources/bs4_book/bs4_book.css
@@ -410,18 +410,7 @@ div.sourceCode > button > i.bi::before {
   width: 1rem;
   content: "";
   vertical-align: -0.125em;
-  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="lightgray" viewBox="0 0 16 16"><path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1v-1z"/><path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h3zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3z"/></svg>');
-  background-repeat: no-repeat;
-  background-size: 1rem 1rem;
-}
-
-div.sourceCode:hover > button > i.bi::before {
-  display: inline-block;
-  height: 1rem;
-  width: 1rem;
-  content: "";
-  vertical-align: -0.125em;
-  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="dark" viewBox="0 0 16 16"><path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1v-1z"/><path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h3zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3z"/></svg>');
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1v-1z"/><path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h3zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3z"/></svg>');
   background-repeat: no-repeat;
   background-size: 1rem 1rem;
 }

--- a/inst/resources/bs4_book/bs4_book.css
+++ b/inst/resources/bs4_book/bs4_book.css
@@ -401,7 +401,7 @@ div.sourceCode {
 .btn-copy {
   position: absolute;
   top: 0rem;
-  right: 0rem;
+  right: -0.5rem; /* coherent with pre margin rule */
 }
 
 div.sourceCode > button {

--- a/inst/resources/bs4_book/bs4_book.css
+++ b/inst/resources/bs4_book/bs4_book.css
@@ -378,9 +378,8 @@ code {
 
 pre code {
   background-color: transparent;
-  white-space: pre-wrap;
-  word-break: break-all;
-  overflow-wrap: break-word;
+  word-break: normal; /* force wide blocks to scroll, not wrap */
+  word-wrap: normal;
 }
 
 pre, code {
@@ -396,7 +395,9 @@ code a:any-link {
 /* copy button */
 
 pre .copy {
-  float: right;
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
 }
 
 pre .copy button {

--- a/inst/resources/bs4_book/bs4_book.css
+++ b/inst/resources/bs4_book/bs4_book.css
@@ -404,6 +404,14 @@ div.sourceCode {
   right: 0rem;
 }
 
+div.sourceCode > button {
+  filter: opacity(40%);
+}
+
+div.sourceCode > button:hover {
+  filter: opacity(100%);
+}
+
 div.sourceCode > button > i.bi::before {
   display: inline-block;
   height: 1rem;

--- a/inst/resources/bs4_book/bs4_book.css
+++ b/inst/resources/bs4_book/bs4_book.css
@@ -410,7 +410,18 @@ div.sourceCode > button > i.bi::before {
   width: 1rem;
   content: "";
   vertical-align: -0.125em;
-  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1v-1z"/><path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h3zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3z"/></svg>');
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="lightgray" viewBox="0 0 16 16"><path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1v-1z"/><path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h3zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3z"/></svg>');
+  background-repeat: no-repeat;
+  background-size: 1rem 1rem;
+}
+
+div.sourceCode:hover > button > i.bi::before {
+  display: inline-block;
+  height: 1rem;
+  width: 1rem;
+  content: "";
+  vertical-align: -0.125em;
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="dark" viewBox="0 0 16 16"><path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1v-1z"/><path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h3zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3z"/></svg>');
   background-repeat: no-repeat;
   background-size: 1rem 1rem;
 }

--- a/inst/resources/bs4_book/bs4_book.css
+++ b/inst/resources/bs4_book/bs4_book.css
@@ -394,18 +394,17 @@ code a:any-link {
 
 /* copy button */
 
-pre .copy {
+div.sourceCode {
+  position: relative;
+}
+
+.btn-copy {
   position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
+  top: 0rem;
+  right: 0rem;
 }
 
-pre .copy button {
-  font-size: 80%;
-  padding: 4px 6px;
-}
-
-pre .copy > button > i.bi::before {
+div.sourceCode > button > i.bi::before {
   display: inline-block;
   height: 1rem;
   width: 1rem;
@@ -416,7 +415,7 @@ pre .copy > button > i.bi::before {
   background-size: 1rem 1rem;
 }
 
-pre .copy > button.btn-copy-checked > .bi::before {
+div.sourceCode > button.btn-copy-checked > .bi::before {
   background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z"/></svg>');
 }
 

--- a/inst/resources/bs4_book/bs4_book.css
+++ b/inst/resources/bs4_book/bs4_book.css
@@ -405,7 +405,7 @@ div.sourceCode {
 }
 
 div.sourceCode > button {
-  filter: opacity(40%);
+  filter: opacity(50%);
 }
 
 div.sourceCode > button:hover {

--- a/inst/resources/bs4_book/bs4_book.js
+++ b/inst/resources/bs4_book/bs4_book.js
@@ -107,15 +107,15 @@ function changeTooltipMessage(element, msg) {
 $(document).ready(function() {
   if(ClipboardJS.isSupported()) {
     // Insert copy buttons
-    var copyButton = "<div class='copy'><button type='button' class='btn btn-copy' title='Copy to clipboard' aria-label='Copy to clipboard' data-toggle='popover' data-placement='top' data-trigger='hover'><i class='bi'></i></button></div>";
-    $(copyButton).appendTo("pre.sourceCode");
+    var copyButton = "<button type='button' class='btn btn-copy' title='Copy to clipboard' aria-label='Copy to clipboard' data-toggle='popover' data-placement='top' data-trigger='hover'><i class='bi'></i></button>";
+    $(copyButton).appendTo("div.sourceCode");
     // Initialize tooltips:
     $('.btn-copy').tooltip({container: 'body', boundary: 'window'});
 
     // Initialize clipboard:
     var clipboard = new ClipboardJS('.btn-copy', {
       text: function(trigger) {
-        return trigger.parentNode.previousSibling.textContent;
+        return trigger.parentNode.textContent;
       }
     });
 

--- a/inst/resources/bs4_book/bs4_book.js
+++ b/inst/resources/bs4_book/bs4_book.js
@@ -108,14 +108,14 @@ $(document).ready(function() {
   if(ClipboardJS.isSupported()) {
     // Insert copy buttons
     var copyButton = "<div class='copy'><button type='button' class='btn btn-copy' title='Copy to clipboard' aria-label='Copy to clipboard' data-toggle='popover' data-placement='top' data-trigger='hover'><i class='bi'></i></button></div>";
-    $(copyButton).prependTo("pre.sourceCode");
+    $(copyButton).appendTo("pre.sourceCode");
     // Initialize tooltips:
     $('.btn-copy').tooltip({container: 'body', boundary: 'window'});
 
     // Initialize clipboard:
     var clipboard = new ClipboardJS('.btn-copy', {
       text: function(trigger) {
-        return trigger.parentNode.nextSibling.textContent;
+        return trigger.parentNode.previousSibling.textContent;
       }
     });
 


### PR DESCRIPTION
This reverts commit dc872256e297ee1ce8e451b42d65b53fc8e3720d (#1187) following discussion in #1040

Plan is to keep the scrolling but have the icon stays on the top right side even when scrolling. 

The button icon will always show so there could be overlap with long line as we no more wrapp. However, the icon is a lighter option than a button, and by default there is an opacity filter. It will be darker on button hover only.

Demo here: https://cderv.github.io/bs4booktesting/with-scroll/



 