### PR TITLE
Allow to use bold label by default for theorem env in non HTML or PDF output.

### DIFF
--- a/R/ebook.R
+++ b/R/ebook.R
@@ -116,13 +116,14 @@ resolve_refs_md = function(content, ref_table, to_md = output_md()) {
     for (j in ids) {
       m = sprintf('\\(\\\\#%s\\)', j)
       if (grepl(m, content[i])) {
-        id = ''; sep = ':'
+        id = ''; sep = ':'; bold = FALSE
         type = gsub('^([^:]+).*$', '\\1', j)
         if (type %in% theorem_abbr) {
           id = sprintf('<span id="%s"></span>', j)
           sep = ''
+          bold = TRUE
         }
-        label = label_prefix(type, sep = sep)(ref_table[j])
+        label = label_prefix(type, sep = sep, bold = bold)(ref_table[j])
         content[i] = sub(m, paste0(id, label, ' '), content[i])
         break
       }

--- a/R/html.R
+++ b/R/html.R
@@ -693,7 +693,7 @@ parse_fig_labels = function(content, global = FALSE) {
 
 
 # given a label, e.g. fig:foo, figure out the appropriate prefix
-label_prefix = function(type, dict = label_names, sep = '') {
+label_prefix = function(type, dict = label_names, sep = '', bold = FALSE) {
   label = i18n('label', type, dict)
   supported_type = c('fig', 'tab', 'eq')
   if (is.function(label)) {
@@ -703,7 +703,8 @@ label_prefix = function(type, dict = label_names, sep = '') {
   }
   function(num = NULL) {
     if (is.null(num)) return(label)
-    paste0(label, num, sep)
+    label = paste0(label, num, sep)
+    if (bold) sprintf("**%s**", label) else label
   }
 }
 

--- a/tests/testit/test-html.R
+++ b/tests/testit/test-html.R
@@ -49,12 +49,16 @@ assert("i18n config can be retrieved ", {
   opts$set(config = list())
 })
 
+assert("label_prefix can set text to bold", {
+  (is.function(label_prefix("fig")))
+  (label_prefix("fig")(1) %==% "Figure 1")
+  (label_prefix("fig", bold = TRUE)(1) %==% "**Figure 1**")
+  (label_prefix("fig", sep = ":")(1) %==% "Figure 1:")
+})
+
 assert("label_prefix retrieves correct config", {
   fun = function(i) paste0("TAB-", i)
   opts$set(config = list(language = list(label = list(tab = fun))))
   (label_prefix("tab") %==% fun)
-  (is.function(label_prefix("fig")))
-  (label_prefix("fig")(1) %==% "Figure 1")
-  (label_prefix("fig", sep = ":")(1) %==% "Figure 1:")
   opts$set(config = list())
 })


### PR DESCRIPTION
This would be a way to resolve #1202 and not reintroducing the `:`

This makes them same style as PDF or HTML output

This probably needs more testing but I think this will correctly only apply on non HTML / non PDF output. 
However, once bold is the default, there is currently no way to change using a config. 

We could make passing a function more generic (https://github.com/rstudio/bookdown/issues/1202#issuecomment-883224612) to apply also on environments. This way the default function could be overwritten.

Creating this as draft for discussion

