### PR TITLE
Pin Boostrap version to 4 in bs4_book theme

### DIFF
--- a/R/bs4_book.R
+++ b/R/bs4_book.R
@@ -192,9 +192,9 @@ bs4_book <- function(theme = bs4_book_theme(),
 #' @export
 #' @rdname bs4_book
 #' @param primary Primary colour: used for links and background of footer.
-#' @param version Passed to `bslib::bs_theme()`. This should not be changed as
-#'   `bs4_book()` has been designed to work with Bootstrap version 4 for now.
-#' @param
+#' @param version Passed to [bslib::bs_theme()]. This should not be changed as
+#'  [bs4_book()] has been designed to work with Bootstrap version 4 for now.
+#' @md
 bs4_book_theme <- function(primary = "#0068D9", version = 4, ...) {
   bslib::bs_theme(...,
     version = 4,

--- a/R/bs4_book.R
+++ b/R/bs4_book.R
@@ -192,8 +192,9 @@ bs4_book <- function(theme = bs4_book_theme(),
 #' @export
 #' @rdname bs4_book
 #' @param primary Primary colour: used for links and background of footer.
-bs4_book_theme <- function(primary = "#0068D9", ...) {
+bs4_book_theme <- function(primary = "#0068D9", version = 4, ...) {
   bslib::bs_theme(...,
+    version = 4,
     primary = primary,
     "font-size-base" = "1rem",
   )

--- a/R/bs4_book.R
+++ b/R/bs4_book.R
@@ -192,6 +192,9 @@ bs4_book <- function(theme = bs4_book_theme(),
 #' @export
 #' @rdname bs4_book
 #' @param primary Primary colour: used for links and background of footer.
+#' @param version Passed to `bslib::bs_theme()`. This should not be changed as
+#'   `bs4_book()` has been designed to work with Bootstrap version 4 for now.
+#' @param
 bs4_book_theme <- function(primary = "#0068D9", version = 4, ...) {
   bslib::bs_theme(...,
     version = 4,

--- a/man/bs4_book.Rd
+++ b/man/bs4_book.Rd
@@ -15,7 +15,7 @@ bs4_book(
   split_bib = FALSE
 )
 
-bs4_book_theme(primary = "#0068D9", ...)
+bs4_book_theme(primary = "#0068D9", version = 4, ...)
 }
 \arguments{
 \item{theme}{A named list or \code{\link[bslib:bs_theme]{bslib::bs_theme()}} object.
@@ -150,3 +150,4 @@ page as expected by social media:
 You can have a look at \href{https://github.com/rstudio/bookdown/blob/master/inst/templates/bs4_book.html}{\code{bs4_book()} HTML template}
 for details on how these variables are used.
 }
+

--- a/man/bs4_book.Rd
+++ b/man/bs4_book.Rd
@@ -31,6 +31,9 @@ view source and edit buttons or a list with repository \code{base} link, default
 \code{\link[rmarkdown:html_document]{rmarkdown::html_document()}}.}
 
 \item{primary}{Primary colour: used for links and background of footer.}
+
+\item{version}{Passed to `bslib::bs_theme()`. This should not be changed as
+`bs4_book()` has been designed to work with Bootstrap version 4 for now.}
 }
 \description{
 This output format is built with \href{https://getbootstrap.com}{bootstrap},

--- a/man/bs4_book.Rd
+++ b/man/bs4_book.Rd
@@ -32,8 +32,8 @@ view source and edit buttons or a list with repository \code{base} link, default
 
 \item{primary}{Primary colour: used for links and background of footer.}
 
-\item{version}{Passed to `bslib::bs_theme()`. This should not be changed as
-`bs4_book()` has been designed to work with Bootstrap version 4 for now.}
+\item{version}{Passed to \code{\link[bslib:bs_theme]{bslib::bs_theme()}}. This should not be changed as
+\code{\link[=bs4_book]{bs4_book()}} has been designed to work with Bootstrap version 4 for now.}
 }
 \description{
 This output format is built with \href{https://getbootstrap.com}{bootstrap},


### PR DESCRIPTION
cc @apreshill 

To do different tweak we think are necessary regarding what is possible for theming


- [x] Pin version 4 of bootstrap: This will prevent any side effect if bslib decide to change its default. 
  Could still be changed with 
  ````yaml
  bookdown::bs4_book:
    theme:
      version: 5
  ````
  if a user really want to