### PR TITLE
Omit the figure and table labels for docx output from pandoc 2.14.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -57,6 +57,8 @@
 
 - When the `site` field is quoted in `index.Rmd`'s YAML data (i.e., `site: "bookdown::bookdown_site"`), **bookdown** fails to identify the root directory of the book (thanks, @dchiu911, #1160).
 
+- The figure/table labels are no longer duplicated in Word output generated from Pandoc 2.14.1 (thanks, @dewittpe, #1223).
+
 # CHANGES IN bookdown VERSION 0.22
 
 ## NEW FEATURES

--- a/R/ebook.R
+++ b/R/ebook.R
@@ -112,6 +112,9 @@ process_markdown = function(
 }
 
 resolve_refs_md = function(content, ref_table, to_md = output_md()) {
+  # for docx output with pandoc 2.14.1, don't add the label prefix (#1223)
+  omit_prefix = knitr::pandoc_to('docx') && rmarkdown::pandoc_available('2.14.1')
+
   ids = names(ref_table)
   # replace (\#fig:label) with Figure x.x:
   for (i in grep('^(<p class="caption|<caption>|Table:|\\\\BeginKnitrBlock)|(!\\[.*?\\]\\(.+?\\))', content)) {
@@ -124,7 +127,9 @@ resolve_refs_md = function(content, ref_table, to_md = output_md()) {
           id = sprintf('<span id="%s"></span>', j)
           sep = ''
         }
-        label = label_prefix(type, sep = sep)(ref_table[j])
+        label = if (omit_prefix && type %in% c('fig', 'tab')) '' else {
+          label_prefix(type, sep = sep)(ref_table[j])
+        }
         content[i] = sub(m, paste0(id, label, ' '), content[i])
         break
       }

--- a/R/word.R
+++ b/R/word.R
@@ -11,6 +11,17 @@ markdown_document2 = function(
     number_sections = number_sections, fig_caption = fig_caption,
     md_extensions = md_extensions, pandoc_args = pandoc_args, ...
   ))
+
+  # for docx, Pandoc 2.14.1 numbers figures/tables globally from 1 to n (#1223)
+  if (!global_numbering && rmarkdown::pandoc_available('2.14.1') &&
+      identical(base_format, rmarkdown::word_document)) {
+    if (!missing(global_numbering)) warning(
+      "'global_numbering = FALSE' does not work for Word output with Pandoc >= 2.14.1; ",
+      "Using 'TRUE' instead."
+    )
+    global_numbering = TRUE
+  }
+
   pre = config$pre_processor
   config$pre_processor = function(metadata, input_file, ...) {
     process_markdown(input_file, from, pandoc_args, global_numbering)


### PR DESCRIPTION
because pandoc will also generate these labels.

Fixes #1223.