### PR TITLE
Do not inline CSS in p.author when there are multiple authors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,8 @@
 
 - The figure/table labels are no longer duplicated in Word output generated from Pandoc 2.14.1 (thanks, @dewittpe, #1223).
 
+- When a book has multiple authors, the CSS styles for each author were inlined in the `<p>` tags, and hence are hard to override. Now the class `multi-author` is applied to each individual author's `<p>` tag, and the CSS rules are defined on this class instead (thanks, @robjhyndman, #1170).
+
 # CHANGES IN bookdown VERSION 0.22
 
 ## NEW FEATURES

--- a/inst/resources/gitbook/css/plugin-bookdown.css
+++ b/inst/resources/gitbook/css/plugin-bookdown.css
@@ -97,3 +97,9 @@ div.proof>*:last-child:after {
 .header-section-number {
   padding-right: .5em;
 }
+#header .multi-author {
+  margin: 0.5em 0 -0.5em 0;
+}
+#header .date {
+  margin-top: 1.5em;
+}

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -123,15 +123,7 @@ $if(subtitle)$
 $endif$
 $for(author)$
 $if(author.name)$
-<style type="text/css">
-  p.author {
-    margin: 1em 0 0 0;
-  }
-  p.date {
-    margin-top: 1.5em;
-  }
-</style>
-<p class="author"><em>$author.name$</em></p>
+<p class="author multi-author"><em>$author.name$</em></p>
 $if(author.affiliation)$
 <address class="author_afil">
 $author.affiliation$<br>

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -123,7 +123,15 @@ $if(subtitle)$
 $endif$
 $for(author)$
 $if(author.name)$
-<p class="author" style="margin: 0.5em 0 -0.5em 0;"><em>$author.name$</em></p>
+<style type="text/css">
+  p.author {
+    margin: 1em 0 0 0;
+  }
+  p.date {
+    margin-top: 1.5em;
+  }
+</style>
+<p class="author"><em>$author.name$</em></p>
 $if(author.affiliation)$
 <address class="author_afil">
 $author.affiliation$<br>
@@ -137,7 +145,7 @@ $else$
 $endif$
 $endfor$
 $if(date)$
-<p class="date" style="margin-top: 1.5em;"><em>$date$</em></p>
+<p class="date"><em>$date$</em></p>
 $endif$
 $if(abstract)$
 <div class="abstract">


### PR DESCRIPTION
Define styles in `#header .multi-author` instead. Fixes #1170.