### PR TITLE
Fix #605: allow non-alnum characters in .html filenames

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,8 @@
 
 ## BUG FIXES
 
+- Removed the requirement for `.html` filenames to be alphanumeric, which fixes a common error "Automatically generated filenames contain duplicated ones: -" (thanks, @psychelzh #605, @AzureRabbit #902, @carloslederman #1000, Ritsu Kitagawa https://stackoverflow.com/q/60014350/559676, Shrek Tan).
+
 - Fix an issue with `bookdown_site()` where the comment in `site:` line key was not supported (thanks, @LDSamson, #1194).
 
 - Figure reference links now point correctly to the top of figures (thanks, @GuillaumeBiessy, #1155).

--- a/R/html.R
+++ b/R/html.R
@@ -395,7 +395,7 @@ split_chapters = function(
         paste(c(num, id), collapse = '-')
       } else id
       if (is.null(nm)) stop('The heading ', x2, ' must have an id')
-      gsub('[^[:alnum:]]+', '-', nm)
+      nm
     })
     if (anyDuplicated(nms)) (if (isTRUE(opts$get('preview'))) warning else stop)(
       'Automatically generated filenames contain duplicated ones: ',


### PR DESCRIPTION
also fix #902 and fix #1000.

I don't really remember why I required the .html filenames to be alphanumeric. After some testing, it seems that arbitrary characters work fine, so I'm removing this requirement.