### PR TITLE
Fix issue with Theorem Fenced div block in Lua filter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bookdown
 Type: Package
 Title: Authoring Books and Technical Documents with R Markdown
-Version: 0.23.1
+Version: 0.23.2
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("JJ", "Allaire", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 - Reverted the fix for #1223 since it only affects a specific version of Pandoc (2.14.1). If this issue affects you, please see #1223 for workarounds.
 
+## BUG FIXES
+
+- Fix an issue with Fenced Divs for Theorem & Proof env in the Lua filter.
+
 # CHANGES IN bookdown VERSION 0.23
 
 ## NEW FEATURES

--- a/inst/rmarkdown/lua/custom-environment.lua
+++ b/inst/rmarkdown/lua/custom-environment.lua
@@ -152,7 +152,7 @@ Div = function (div)
             table.insert(div.content[#div.content].content, pandoc.RawInline('tex', '\n' .. endEnv))
         else
             table.insert(div.content, 1, pandoc.RawBlock('tex', beginEnv))
-            table.insert(div.content, pandoc.RawInline('tex', endEnv))
+            table.insert(div.content, pandoc.RawBlock('tex', endEnv))
         end
     elseif (FORMAT:match 'html') then
         -- if div is already processed by eng_theorem, it would also modify it.


### PR DESCRIPTION
This should fix #1233 and also https://github.com/yihui/tinytex/issues/324

A similar issue was also reported in French slack grrr where this was not working

````markdown
---
output:
  bookdown::pdf_document2: 
    keep_md: true
    keep_tex: true
---

::: {.theorem}

Hello2

```{r}
1+1
```

:::
````

It ended up being a mistake when updating the code in #1145