### PR TITLE
Typo in template project 02-cross-refs.Rmd

### DIFF
--- a/inst/rstudio/templates/project/resources/common/02-cross-refs.Rmd
+++ b/inst/rstudio/templates/project/resources/common/02-cross-refs.Rmd
@@ -15,7 +15,7 @@ There are two steps to cross-reference any heading:
 
 ## Captioned figures and tables
 
-Figures and tables *with captions* can also be cross-referenced from elsewhere in your book using `\@ref(fig:chunk-label)` and `\@ref(tag:chunk-label)`, respectively.
+Figures and tables *with captions* can also be cross-referenced from elsewhere in your book using `\@ref(fig:chunk-label)` and `\@ref(tab:chunk-label)`, respectively.
 
 See Figure \@ref(fig:nice-fig).
 


### PR DESCRIPTION
Typo: `tag` instead of `tab` for tables cross references.

Thanks for your work!