### PR TITLE
Accept custom template for `bs4_book()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bookdown
 Type: Package
 Title: Authoring Books and Technical Documents with R Markdown
-Version: 0.23.4
+Version: 0.23.5
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("JJ", "Allaire", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 - Reverted the fix for #1223 since it only affects a specific version of Pandoc (2.14.1). If this issue affects you, please see #1223 for workarounds.
 
+- `bs4_book()` now has the `template` argument like `gitbook()` (thanks, @shinneuro, #1247).
+
 ## BUG FIXES
 
 - Fix an issue with Fenced Divs for Theorem & Proof environments in the Lua filter (thanks, @tchevri, #1233).

--- a/R/bs4_book.R
+++ b/R/bs4_book.R
@@ -14,9 +14,14 @@
 #'   view source and edit buttons or a list with repository `base` link, default
 #'   `branch`, `subdir` and `icon`
 #'   (see "Specifying the repository" in \url{https://bookdown.org/yihui/bookdown/html.html#bootstrap4-style}).
-#' @param lib_dir,pandoc_args,extra_dependencies,split_bib,... Passed on to
-#'   [rmarkdown::html_document()].
-#'
+#' @param lib_dir,pandoc_args,extra_dependencies,split_bib,... Passed on to [rmarkdown::html_document()].
+#' @param template Pandoc template to use for rendering. Pass `"default"` to use
+#'   the bookdown default template; pass a path to use a custom template. The
+#'   default template should be sufficient for most use cases. For advanced user
+#'   only, in case you want to develop a custom template, we highly recommend to
+#'   start from the default template:
+#'   <https://github.com/rstudio/bookdown/blob/master/inst/templates/bs4_book.html>.
+#'   Otherwise, some feature may not work anymore.
 #' @export
 #' @md
 bs4_book <- function(theme = bs4_book_theme(),
@@ -37,7 +42,7 @@ bs4_book <- function(theme = bs4_book_theme(),
 
   # check for custom template
   if (identical(template, 'default')) {
-    template = bookdown_file('templates', 'bs4_book.html')
+    template <- bookdown_file('templates', 'bs4_book.html')
   }
 
   config <- rmarkdown::html_document(
@@ -685,7 +690,6 @@ bs4_check_dots <- function(...) {
     "anchor_sections",
     "number_sections",
     "self_contained",
-    # "template",
     "toc"
   )
   for (arg in fixed) {

--- a/R/bs4_book.R
+++ b/R/bs4_book.R
@@ -25,6 +25,7 @@ bs4_book <- function(theme = bs4_book_theme(),
                      lib_dir = "libs",
                      pandoc_args = NULL,
                      extra_dependencies = NULL,
+                     template = 'default',
                      split_bib = FALSE) {
   check_packages(bs4_book_deps())
   bs4_check_dots(...)
@@ -34,13 +35,18 @@ bs4_book <- function(theme = bs4_book_theme(),
     theme <- do.call(bs4_book_theme, theme)
   }
 
+  # check for custom template
+  if (identical(template, 'default')) {
+    template = bookdown_file('templates', 'bs4_book.html')
+  }
+
   config <- rmarkdown::html_document(
     toc = FALSE,
     number_sections = TRUE,
     anchor_sections = FALSE,
     self_contained = FALSE,
     theme = NULL,
-    template = bookdown_file("templates", "bs4_book.html"),
+    template = template,
     pandoc_args = pandoc_args2(pandoc_args),
     lib_dir = lib_dir,
     extra_dependencies = c(bs4_book_dependency(theme), extra_dependencies),
@@ -679,7 +685,7 @@ bs4_check_dots <- function(...) {
     "anchor_sections",
     "number_sections",
     "self_contained",
-    "template",
+    # "template",
     "toc"
   )
   for (arg in fixed) {

--- a/man/bs4_book.Rd
+++ b/man/bs4_book.Rd
@@ -12,6 +12,7 @@ bs4_book(
   lib_dir = "libs",
   pandoc_args = NULL,
   extra_dependencies = NULL,
+  template = "default",
   split_bib = FALSE
 )
 
@@ -28,8 +29,15 @@ view source and edit buttons or a list with repository \code{base} link, default
 \code{branch}, \code{subdir} and \code{icon}
 (see "Specifying the repository" in \url{https://bookdown.org/yihui/bookdown/html.html#bootstrap4-style}).}
 
-\item{lib_dir, pandoc_args, extra_dependencies, split_bib, ...}{Passed on to
-\code{\link[rmarkdown:html_document]{rmarkdown::html_document()}}.}
+\item{lib_dir, pandoc_args, extra_dependencies, split_bib, ...}{Passed on to \code{\link[rmarkdown:html_document]{rmarkdown::html_document()}}.}
+
+\item{template}{Pandoc template to use for rendering. Pass \code{"default"} to use
+the bookdown default template; pass a path to use a custom template. The
+default template should be sufficient for most use cases. For advanced user
+only, in case you want to develop a custom template, we highly recommend to
+start from the default template:
+\url{https://github.com/rstudio/bookdown/blob/master/inst/templates/bs4_book.html}.
+Otherwise, some feature may not work anymore.}
 
 \item{primary}{Primary colour: used for links and background of footer.}
 


### PR DESCRIPTION
I would love to tweak some of the elements in the bs4_book template.
The custom template feature is currently supported by gitbook but not by bs4_book.
This PR removes restrictions that barred bs4_book from accepting template argument.
