### PR TITLE
Put gitbook dependencies before extra_dependencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 ## BUG FIXES
 
+- `extra_dependencies` in `gitbook()` will now be appended after Gitbook's dependencies so that it does not get overridden (thanks, @ThierryO, @linogaliana, #1101, #1248).
+
 - Fix an issue with Fenced Divs for Theorem & Proof environments in the Lua filter (thanks, @tchevri, #1233).
 
 - `gitbook(self_contained = TRUE)` was slow when the output contains base64-encoded images (thanks, @king2bob, #1236).

--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -31,7 +31,7 @@ gitbook = function(
   gb_config = config
   html_document2 = function(..., extra_dependencies = list()) {
     rmarkdown::html_document(
-      ..., extra_dependencies = c(extra_dependencies, gitbook_dependency(table_css, gb_config))
+      ..., extra_dependencies = c(gitbook_dependency(table_css, gb_config), extra_dependencies)
     )
   }
   if (identical(template, 'default')) {


### PR DESCRIPTION
so that extra_dependencies is not overridden by some Gitbook deps

This will close #1101

It should not be impactful and `extra_dependencies` must no be so used, and those who tried must have faced the issue. 

See discussion in #1101

Let's change the order. 