### PR TITLE
Add option to prevent search engine indexing

### DIFF
--- a/inst/templates/bs4_book.html
+++ b/inst/templates/bs4_book.html
@@ -23,6 +23,7 @@
   $if(twitter-handle)$<meta name="twitter:site" content="@$twitter-handle$" />$endif$
   $if(description)$<meta name="twitter:description" content="$description$" />$endif$
   $if(cover-image)$<meta name="twitter:image" content="$url$/$cover-image$" />$endif$
+  $if(robots)$<meta name="robots" content="$robots$" />$endif$
   <!-- JS -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" integrity="sha256-inc5kl9MA1hkeYUt+EC3BhlIgyp/2jDIyBLS6k3UxPI=" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/fuse.js/6.4.6/fuse.js" integrity="sha512-zv6Ywkjyktsohkbp9bb45V6tEMoWhzFzXis+LrMehmJZZSys19Yxf1dopHx7WzIKxr5tK2dVcYmaCk2uqdjF4A==" crossorigin="anonymous"></script>

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -14,6 +14,7 @@
   $if(cover-image)$<meta property="og:image" content="$url$/$cover-image$" />$endif$
   $if(description)$<meta property="og:description" content="$description$" />$endif$
   $if(github-repo)$<meta name="github-repo" content="$github-repo$" />$endif$
+  $if(robots)$<meta name="robots" content="$robots$" />$endif$
 
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:title" content="$pagetitle$" />


### PR DESCRIPTION
Hello,

For the use case where one is working on an unfinished online book, I think the option to prevent indexing from search engines would be nice. This can be done with the [`robots` meta tag](https://developers.google.com/search/docs/advanced/crawling/block-indexing). I added the tag option to the gitbook and bs4_book HTML templates. 
A list of the tag values supported by various search engines can be found here: https://yoast.com/robots-meta-tags/

