### PR TITLE
Add an option to opt-out using custom environment lua filter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bookdown
 Type: Package
 Title: Authoring Books and Technical Documents with R Markdown
-Version: 0.24.3
+Version: 0.24.4
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("JJ", "Allaire", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## NEW FEATURES
 
-- Set option `bookdown.theorem.use = FALSE` to opt-out **bookdown** special Theorem and Proof environment syntax. `options(bookdown.theorem.use = FALSE)` must be called before the function to render the book, e.g in a project's `.Rprofile`. This can be useful for advanced users who only want PDF output and needs to handle themselves the environment using LaTeX directly, or [Custom Blocks](https://bookdown.org/yihui/rmarkdown-cookbook/custom-blocks.html) syntax without **bookdown** interfering (thanks, @finkelshtein, #1285).
+- Set option `bookdown.theorem.enabled = FALSE` to opt-out **bookdown** special Theorem and Proof environment syntax. `options(bookdown.theorem.enabled = FALSE)` must be called before the function to render the book, e.g in a project's `.Rprofile`. This can be useful for advanced users who only want PDF output and needs to handle themselves the environment using LaTeX directly, or [Custom Blocks](https://bookdown.org/yihui/rmarkdown-cookbook/custom-blocks.html) syntax without **bookdown** interfering (thanks, @finkelshtein, #1285).
 
 ## BUG FIXES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # CHANGES IN bookdown VERSION 0.25
 
+## NEW FEATURES
+
+- Set option `bookdown.theorem.use = FALSE` to opt-out **bookdown** special Theorem and Proof environment syntax. `options(bookdown.theorem.use = FALSE)` must be called before the function to render the book, e.g in a project's `.Rprofile`. This can be useful for advanced users who only want PDF output and needs to handle themselves the environment using LaTeX directly, or [Custom Blocks](https://bookdown.org/yihui/rmarkdown-cookbook/custom-blocks.html) syntax without **bookdown** interfering (thanks, @finkelshtein, #1285).
+
 ## BUG FIXES
 
 - Fix an issue with Pandoc 2.15 and footnote relocation in each chapter (#1275).

--- a/R/utils.R
+++ b/R/utils.R
@@ -33,7 +33,7 @@ common_format_config = function(
   if (file_scope) config$file_scope = md_chapter_splitter
 
   # prepend the custom-environment filter unless opt-out
-  if (getOption("bookdown.theorem.use", TRUE)) {
+  if (getOption("bookdown.theorem.enabled", TRUE)) {
     config$pandoc$lua_filters = c(
       lua_filter("custom-environment.lua"),
       config$pandoc$lua_filters

--- a/R/utils.R
+++ b/R/utils.R
@@ -32,10 +32,13 @@ common_format_config = function(
   # provide file_scope if requested
   if (file_scope) config$file_scope = md_chapter_splitter
 
-  # prepend the custom-environment filter
-  config$pandoc$lua_filters = c(
-    lua_filter("custom-environment.lua"), config$pandoc$lua_filters
-  )
+  # prepend the custom-environment filter unless opt-out
+  if (getOption("bookdown.theorem.use", TRUE)) {
+    config$pandoc$lua_filters = c(
+      lua_filter("custom-environment.lua"),
+      config$pandoc$lua_filters
+    )
+  }
   # and add bookdown metadata file for the filter to work
   config$pandoc$args = c(bookdown_yml_arg(), config$pandoc$args)
 


### PR DESCRIPTION
This PR closes #1285 by adding an option `bookdown.theorem.use` to opt out using the Lua filter `custom-environments.lua` to handle special environment supported by **bookdown**. Those described in https://bookdown.org/yihui/bookdown/markdown-extensions-by-bookdown.html#theorems


Option must be set to FALSE before running the function to render the document. 
Example: 

````
options(bookdown.theorem.use = FALSE)
rmarkdown::render("test.Rmd", bookdown::pdf_document2())
````

Option name maybe not be perfect. We alreary have an option `bookdown.theorem.preamble` that can be set to FALSE to prevent bookdown to include the LaTeX preamble itself. If you have another idea, happy to change the name. 

