### PR TITLE
Adapt lua filter to pandoc 2.17 changes in Metadata type 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,7 +61,7 @@ License: GPL-3
 Imports:
     htmltools (>= 0.3.6),
     knitr (>= 1.31),
-    rmarkdown (>= 2.9),
+    rmarkdown (>= 2.11.11),
     jquerylib,
     xfun (>= 0.22),
     tinytex (>= 0.12),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,7 +61,7 @@ License: GPL-3
 Imports:
     htmltools (>= 0.3.6),
     knitr (>= 1.31),
-    rmarkdown (>= 2.11.11),
+    rmarkdown (>= 2.11.12),
     jquerylib,
     xfun (>= 0.22),
     tinytex (>= 0.12),
@@ -91,3 +91,4 @@ Encoding: UTF-8
 Config/Needs/book: remotes, webshot
 Config/testthat/edition: 3
 VignetteBuilder: knitr
+Remotes: rstudio/rmarkdown

--- a/inst/rmarkdown/lua/custom-environment.lua
+++ b/inst/rmarkdown/lua/custom-environment.lua
@@ -90,7 +90,7 @@ Meta = function(m)
     if (bookdownmeta and bookdownmeta.language and bookdownmeta.language.label) then
         -- For internationalization feature of bookdown
         for k,v in pairs(bookdownmeta.language.label) do
-            if (type(v) == 'table' and v.t == 'MetaInlines' and proof_label[k] ~= nil) then
+            if (type(v) == 'Inlines' and proof_label[k] ~= nil) then
                 -- remove any undesired space (3 or less)
                 proof_label[k] = pandoc.utils.stringify(v):gsub("%.?%s?%s?%s?$", "")
                 print_debug("Translation-> "..k..":", proof_label[k])

--- a/inst/rmarkdown/lua/custom-environment.lua
+++ b/inst/rmarkdown/lua/custom-environment.lua
@@ -2,7 +2,10 @@
      A Pandoc 2 lua filter to deal with custom environment in bookdown
 --]]
 
--- REQUIREMENTS: Load shared lua filter - see `shared.lua` in rmarkdown for more details.
+-- REQUIREMENTS: Load shared lua function - see `shared.lua` in rmarkdown for more details.
+--  * pandocAvailable()
+--  * backward compatible type() function
+--  * print_debug()
 dofile(os.getenv 'RMARKDOWN_LUA_SHARED')
 
 --[[
@@ -35,27 +38,6 @@ local proof_label = {
     remark = 'Remark',
     solution = 'Solution'
 }
-
--- for debuging purpose
-local debug_mode = os.getenv("DEBUG_PANDOC_LUA") == "TRUE"
-local function print_debug(label,obj,iter)
-    obj = obj or nil
-    iter = iter or pairs
-    label = label or ""
-    label = "DEBUG (from custom-environment.lua): "..label
-    if (debug_mode) then
-        if not obj then
-            print(label.." nil")
-        elseif (type(obj) == "string") then
-            print(label.." "..obj)
-        elseif type(obj) == "table" then
-            for k,v in iter(obj) do
-                print(label.."id:"..k.. " val:"..v)
-            end
-        end
-    end
-    return nil
-end
 
 -- create a unique id for a div with none provided
 local counter = 0
@@ -90,7 +72,7 @@ Meta = function(m)
     if (bookdownmeta and bookdownmeta.language and bookdownmeta.language.label) then
         -- For internationalization feature of bookdown
         for k,v in pairs(bookdownmeta.language.label) do
-            if (type(v) == 'Inlines' and proof_label[k] ~= nil) then
+            if (pandoc_type(v) == 'Inlines' and proof_label[k] ~= nil) then
                 -- remove any undesired space (3 or less)
                 proof_label[k] = pandoc.utils.stringify(v):gsub("%.?%s?%s?%s?$", "")
                 print_debug("Translation-> "..k..":", proof_label[k])

--- a/inst/rmarkdown/lua/custom-environment.lua
+++ b/inst/rmarkdown/lua/custom-environment.lua
@@ -2,6 +2,20 @@
      A Pandoc 2 lua filter to deal with custom environment in bookdown
 --]]
 
+-- REQUIREMENTS: Load shared lua filter - see `shared.lua` in rmarkdown for more details.
+dofile(os.getenv 'RMARKDOWN_LUA_SHARED')
+
+--[[
+  About the requirement:
+  * PANDOC_VERSION -> 2.1
+]]
+if (not pandocAvailable {2,1}) then
+    io.stderr:write("[WARNING] (latex-div.lua) requires at least Pandoc 2.1. Lua Filter skipped.\n")
+    return {}
+end
+
+-- START OF THE FILTER'S FUNCTIONS --
+
 -- theorem types available to be used
 local theorem_abbr = {
     theorem = 'thm',


### PR DESCRIPTION
This is the same as  initial https://github.com/rstudio/pagedown/pull/269 and other related change. 

It uses new shared Lua function in **rmarkdown**  https://github.com/rstudio/rmarkdown/pull/2291

This fixes #1302 

Tested manually and it now works as expected. 
