### PR TITLE
do not wrap HTML as it was done by default before Pandoc 2.17

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bookdown
 Type: Package
 Title: Authoring Books and Technical Documents with R Markdown
-Version: 0.24.5
+Version: 0.24.6
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("JJ", "Allaire", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,9 +6,11 @@
 
 ## BUG FIXES
 
-- Fix an issue with Pandoc 2.15 and footnote relocation in each chapter (#1275).
-
 - Fix an issue with Pandoc 2.17 and internationalization of Proof-like environment (#1302).
+
+- Fix an issue with Pandoc 2.17 and cross referencing sections in non HTML format (thanks, @N0rbert, #7862).
+
+- Fix an issue with Pandoc 2.15 and footnote relocation in each chapter (#1275).
 
 - Fix an issue with `html_book()` and `toc.css` not working correctly with recent pandoc (thanks, @florisvdh, #1268).
 

--- a/R/ebook.R
+++ b/R/ebook.R
@@ -86,7 +86,8 @@ process_markdown = function(
   on.exit(file.remove(intermediate_html), add = TRUE)
   rmarkdown::pandoc_convert(
     input_file, 'html', from, intermediate_html, TRUE,
-    c(pandoc_args, '--section-divs', '--mathjax', '--number-sections')
+    c(pandoc_args, '--section-divs', '--mathjax', '--number-sections',
+      if (rmarkdown::pandoc_available("2.17")) c('--wrap', 'none'))
   )
   x = read_utf8(intermediate_html)
   x = clean_html_tags(x)

--- a/R/ebook.R
+++ b/R/ebook.R
@@ -86,8 +86,7 @@ process_markdown = function(
   on.exit(file.remove(intermediate_html), add = TRUE)
   rmarkdown::pandoc_convert(
     input_file, 'html', from, intermediate_html, TRUE,
-    c(pandoc_args, '--section-divs', '--mathjax', '--number-sections',
-      if (rmarkdown::pandoc_available("2.17")) c('--wrap', 'none'))
+    c(pandoc_args2(pandoc_args), '--section-divs', '--mathjax', '--number-sections')
   )
   x = read_utf8(intermediate_html)
   x = clean_html_tags(x)

--- a/tests/testthat/_snaps/word/md-resolve-ref.md
+++ b/tests/testthat/_snaps/word/md-resolve-ref.md
@@ -1,0 +1,7 @@
+# 1 Theory
+
+see <a href="#label1">1.1</a>
+
+## 1.1 Some other header
+
+Content

--- a/tests/testthat/_snaps/word/md-resolve-ref.md
+++ b/tests/testthat/_snaps/word/md-resolve-ref.md
@@ -1,7 +1,0 @@
-# 1 Theory
-
-see <a href="#label1">1.1</a>
-
-## 1.1 Some other header
-
-Content

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -24,6 +24,23 @@ skip_if_pandoc <- function(ver = NULL) {
   }
 }
 
+local_rmd_file <- function(..., .env = parent.frame()) {
+  path <- withr::local_tempfile(.local_envir = .env, fileext = ".Rmd")
+  xfun::write_utf8(c(...), path)
+  path
+}
+
+local_render <- function(input, ..., .env = parent.frame()) {
+  skip_if_not_pandoc()
+  output_file <- withr::local_tempfile(.local_envir = .env)
+  rmarkdown::render(input, output_file = output_file, quiet = TRUE, ...)
+}
+
+.render_and_read <- function(input, ...) {
+  skip_if_not_pandoc()
+  res <- local_render()
+  xfun::read_utf8(res)
+}
 
 local_book <- function(name = "book",
                        title = "Awesome Cookbook",

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -38,7 +38,7 @@ local_render <- function(input, ..., .env = parent.frame()) {
 
 .render_and_read <- function(input, ...) {
   skip_if_not_pandoc()
-  res <- local_render()
+  res <- local_render(input, ...)
   xfun::read_utf8(res)
 }
 

--- a/tests/testthat/test-word.R
+++ b/tests/testthat/test-word.R
@@ -1,0 +1,10 @@
+test_that("process_markdown() correctly resolves reference", {
+  skip_if_not_pandoc()
+  # testing using markdown_document2() for snapshotting easier
+  rmd <- local_rmd_file(
+    "# Theory {#theory}", "", "see \\@ref(label1)", "",
+    "## Some other header {#label1}", "", "Content"
+  )
+  out <- local_render(rmd, output_format = markdown_document2())
+  expect_snapshot_file(out, "md-resolve-ref.md")
+})

--- a/tests/testthat/test-word.R
+++ b/tests/testthat/test-word.R
@@ -5,6 +5,6 @@ test_that("process_markdown() correctly resolves reference", {
     "# Theory {#theory}", "", "see \\@ref(label1)", "",
     "## Some other header {#label1}", "", "Content"
   )
-  out <- local_render(rmd, output_format = markdown_document2())
-  expect_snapshot_file(out, "md-resolve-ref.md")
+  content <- .render_and_read(rmd, output_format = markdown_document2())
+  expect_match(content, 'see <a href="#label1">1.1</a>', fixed = TRUE, all = FALSE)
 })


### PR DESCRIPTION
as this breaks our parsing process for section references.

This fixes #1301

THis PR is for now limited to the related issue but there are maybe other processing affected.