### PR TITLE
resolve format in `render_book()` directly for `rmd_files` config resolution

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -14,7 +14,7 @@
 #'   project directory. For filenames, if \code{preview = TRUE}, only files
 #'   specified in this argument are rendered, otherwise all R Markdown files
 #'   specified by the book are rendered.
-#' @param output_format,...,clean,envir Arguments to be passed to
+#' @param output_format,output_options,...,clean,envir Arguments to be passed to
 #'   \code{rmarkdown::\link{render}()}. For \code{preview_chapter()}, \code{...}
 #'   is passed to \code{render_book()}. See \code{rmarkdown::\link{render}()}
 #'   and \href{https://bookdown.org/yihui/bookdown/build-the-book.html}{the
@@ -56,7 +56,7 @@
 #' bookdown::render_book("my_book_project")
 #' }
 render_book = function(
-  input = ".", output_format = NULL, ..., clean = TRUE, envir = parent.frame(),
+  input = ".", output_format = NULL, output_options = NULL, ..., clean = TRUE, envir = parent.frame(),
   clean_envir = !interactive(), output_dir = NULL, new_session = NA,
   preview = FALSE, config_file = '_bookdown.yml'
 ) {
@@ -74,6 +74,11 @@ render_book = function(
   }
 
   format = NULL  # latex or html
+  if (is.null(output_format)) {
+    output_format = rmarkdown::resolve_output_format(
+      input, output_format = output_format, output_options = output_options
+    )
+  }
   if (is.list(output_format)) {
     format = output_format$bookdown_output_format
     if (!is.character(format) || !(format %in% c('latex', 'html'))) format = NULL

--- a/man/render_book.Rd
+++ b/man/render_book.Rd
@@ -8,6 +8,7 @@
 render_book(
   input = ".",
   output_format = NULL,
+  output_options = NULL,
   ...,
   clean = TRUE,
   envir = parent.frame(),
@@ -27,7 +28,7 @@ project directory. For filenames, if \code{preview = TRUE}, only files
 specified in this argument are rendered, otherwise all R Markdown files
 specified by the book are rendered.}
 
-\item{output_format, ..., clean, envir}{Arguments to be passed to
+\item{output_format, output_options, ..., clean, envir}{Arguments to be passed to
 \code{rmarkdown::\link{render}()}. For \code{preview_chapter()}, \code{...}
 is passed to \code{render_book()}. See \code{rmarkdown::\link{render}()}
 and \href{https://bookdown.org/yihui/bookdown/build-the-book.html}{the


### PR DESCRIPTION
This fixes #1323 

Currently, `render_book()` is called with `output_format = NULL` by default. This will let `rmarkdown::render()` do the resolution to the first format as with other docs. 

However, `rmd_files` configuration in `_bookdown.yaml` can require the `format` to resolve the files to pass to `render()`. 
This is really the case when a per-format `rmd_files` config is provided - quite rare probably as this is the first time this issue is encountered. 

Build book button is working fine as the format is resolved by the IDE (not sure with which function) and `output_format` name is added in the call to `render_book()`. 

First idea here is to fully resolve the format (using `resolve_output_format()`), when none is provided - so basically doing what `rmarkdown::render()` will do later.  This require explicitly passing `output_options` argument.

Other approach would be to use `rmarkdown::all_output_formats()` like `output_format = "all"` but keep only the first one. I am just not sure that is equivalent to what `render()` is doing.  I don't want to break current `render_book()` calls to fix this specific issue. 

Does current solution looks ok to you ? 