### PR TITLE
Fix TOC issues with pandoc 2.18 in gitbook()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bookdown
 Type: Package
 Title: Authoring Books and Technical Documents with R Markdown
-Version: 0.25.4
+Version: 0.25.5
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("JJ", "Allaire", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN bookdown VERSION 0.26
 
+- Fix issues with TOC in `gitbook()` and Pandoc 2.18 (thanks, @avraam-inside, #1326, #1329).
+
 - Fix an issue with per-format `rmd_files` config when no `output_format` was provided in `render_book()` (thanks, @ellessenne, #1323).
 
 - Added support for theorem/proof environments back for Word/EPUB/ODT output (thanks, @N0rbert, #1313).

--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -192,6 +192,9 @@ gitbook_toc = function(x, cur, config) {
   if (i2 - i1 < 2) return(x)
   toc = x[(i1 + 1):(i2 - 1)]
 
+  # Remove possible empty span due to anchor section
+  toc = gsub("<span></span>(?=</a>)", "", toc, perl = TRUE)
+
   # numbered sections
   r = '^<li><a href="([^#]*)(#[^"]+)"[^>]*><span class="toc-section-number">([.A-Z0-9]+)</span>(.+)(</a>.*)$'
   i = grep(r, toc)

--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -193,7 +193,7 @@ gitbook_toc = function(x, cur, config) {
   toc = x[(i1 + 1):(i2 - 1)]
 
   # numbered sections
-  r = '^<li><a href="([^#]*)(#[^"]+)"><span class="toc-section-number">([.A-Z0-9]+)</span>(.+)(</a>.*)$'
+  r = '^<li><a href="([^#]*)(#[^"]+)"[^>]*><span class="toc-section-number">([.A-Z0-9]+)</span>(.+)(</a>.*)$'
   i = grep(r, toc)
   toc[i] = gsub(
     r,
@@ -203,7 +203,7 @@ gitbook_toc = function(x, cur, config) {
   toc[i] = sub(' data-path="">', paste0(' data-path="', with_ext(cur, '.html'), '">'), toc[i])
 
   # unnumbered sections
-  r = '^<li><a href="([^#]*)(#[^"]+)">((.+)</a>.*)$'
+  r = '^<li><a href="([^#]*)(#[^"]+)"[^>]*>((.+)</a>.*)$'
   i = grep(r, toc)
   toc[i] = gsub(
     r,

--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -203,7 +203,7 @@ gitbook_toc = function(x, cur, config) {
   toc[i] = sub(' data-path="">', paste0(' data-path="', with_ext(cur, '.html'), '">'), toc[i])
 
   # unnumbered sections
-  r = '^<li><a href="([^#]*)(#[^"]+)">([^<]+</a>.*)$'
+  r = '^<li><a href="([^#]*)(#[^"]+)">((.+)</a>.*)$'
   i = grep(r, toc)
   toc[i] = gsub(
     r,

--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -193,7 +193,7 @@ gitbook_toc = function(x, cur, config) {
   toc = x[(i1 + 1):(i2 - 1)]
 
   # numbered sections
-  r = '^<li><a href="([^#]*)(#[^"]+)"><span class="toc-section-number">([.A-Z0-9]+)</span>(.+)(</a>.*)$'
+  r = '^<li><a href="([^#]*)(#[^"]+)"[^>]*><span class="toc-section-number">([.A-Z0-9]+)</span>(.+)(</a>.*)$'
   i = grep(r, toc)
   toc[i] = gsub(
     r,
@@ -203,7 +203,7 @@ gitbook_toc = function(x, cur, config) {
   toc[i] = sub(' data-path="">', paste0(' data-path="', with_ext(cur, '.html'), '">'), toc[i])
 
   # unnumbered sections
-  r = '^<li><a href="([^#]*)(#[^"]+)">([^<]+</a>.*)$'
+  r = '^<li><a href="([^#]*)(#[^"]+)"[^>]*<>([^<]+</a>.*)$'
   i = grep(r, toc)
   toc[i] = gsub(
     r,

--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -193,7 +193,7 @@ gitbook_toc = function(x, cur, config) {
   toc = x[(i1 + 1):(i2 - 1)]
 
   # numbered sections
-  r = '^<li><a href="([^#]*)(#[^"]+)"[^>]*><span class="toc-section-number">([.A-Z0-9]+)</span>(.+)(</a>.*)$'
+  r = '^<li><a href="([^#]*)(#[^"]+)"><span class="toc-section-number">([.A-Z0-9]+)</span>(.+)(</a>.*)$'
   i = grep(r, toc)
   toc[i] = gsub(
     r,
@@ -203,7 +203,7 @@ gitbook_toc = function(x, cur, config) {
   toc[i] = sub(' data-path="">', paste0(' data-path="', with_ext(cur, '.html'), '">'), toc[i])
 
   # unnumbered sections
-  r = '^<li><a href="([^#]*)(#[^"]+)"[^>]*<>([^<]+</a>.*)$'
+  r = '^<li><a href="([^#]*)(#[^"]+)">([^<]+</a>.*)$'
   i = grep(r, toc)
   toc[i] = gsub(
     r,

--- a/R/html.R
+++ b/R/html.R
@@ -944,11 +944,11 @@ restore_part_html = function(x, remove = TRUE) {
     )
   }
 
-  r = '^<li><a href="[^"]*">\\(PART\\*\\) (.+)</a>(.+)$'
+  r = '^<li><a href="[^"]*"[^>]*>\\(PART\\*\\) (.+)</a>(.+)$'
   i = grep(r, x)
   x[i] = gsub(r, '<li class="part"><span><b>\\1</b></span>\\2', x[i])
 
-  r = '^<li><a href="[^"]*">\\(PART\\) (.+)</a>(.+)$'
+  r = '^<li><a href="[^"]*"[^>]*>\\(PART\\) (.+)</a>(.+)$'
   i = grep(r, x)
   if (length(i) == 0) return(x)
   x[i] = mapply(

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -36,6 +36,14 @@ local_render <- function(input, ..., .env = parent.frame()) {
   rmarkdown::render(input, output_file = output_file, quiet = TRUE, ...)
 }
 
+local_render_book <- function(input, ..., .env = parent.frame()) {
+  skip_if_not_pandoc()
+  proj <- withr::local_tempdir(.local_envir = .env)
+  file.copy(normalizePath(input), proj)
+  withr::local_dir(proj)
+  render_book(basename(input), quiet = TRUE, ...)
+}
+
 .render_and_read <- function(input, ...) {
   skip_if_not_pandoc()
   res <- local_render(input, ...)

--- a/tests/testthat/test-gitbook.R
+++ b/tests/testthat/test-gitbook.R
@@ -35,5 +35,5 @@ test_that("gitbook_toc correctly process pandoc html with anchor section", {
   H2 <- xml2::xml_find_all(TOC, ".//li/a")
   expect_equal(xml2::xml_text(H2), c("1.1 CHAP1", "1.2 CHAP2"))
   # no empty spans https://github.com/rstudio/bookdown/issues/1326
-  expect_false(all(xml2::xml_find_lgl(TOC, "boolean(./a/span/text())")))
+  expect_true(all(xml2::xml_find_lgl(TOC, "not(boolean(./a/span[count(node()) = 0]))")))
 })

--- a/tests/testthat/test-gitbook.R
+++ b/tests/testthat/test-gitbook.R
@@ -34,4 +34,6 @@ test_that("gitbook_toc correctly process pandoc html with anchor section", {
   expect_equal(xml2::xml_text(H1), c("1 T1", "T2"))
   H2 <- xml2::xml_find_all(TOC, ".//li/a")
   expect_equal(xml2::xml_text(H2), c("1.1 CHAP1", "1.2 CHAP2"))
+  # no empty spans https://github.com/rstudio/bookdown/issues/1326
+  expect_false(all(xml2::xml_find_lgl(TOC, "boolean(./a/span/text())")))
 })

--- a/tests/testthat/test-gitbook.R
+++ b/tests/testthat/test-gitbook.R
@@ -1,0 +1,37 @@
+test_that("gitbook_toc correctly process pandoc html without anchor section", {
+  skip_on_cran()
+  skip_if_not_pandoc()
+  skip_if_not_installed("xml2")
+  rmd <- local_rmd_file(c("---", "title: test", "---", "",
+                          "# T1", "", "## CHAP1", "",
+                          "# T2 {-}", "", "## CHAP2"))
+  res <- local_render_book(rmd, output_format = gitbook(anchor_sections = FALSE))
+  content <- xml2::read_html(res)
+  TOC <- xml2::xml_find_all(content, "//div[@class='book-summary']/nav/ul/li")
+  expect_equal(xml2::xml_attr(TOC, "class"), c("chapter", "chapter"))
+  expect_equal(xml2::xml_attr(TOC, "data-level"), c("1", ""))
+  expect_equal(xml2::xml_attr(TOC, "data-path"), c("t1.html", "t2.html"))
+  H1 <- xml2::xml_find_all(TOC, "a")
+  expect_equal(xml2::xml_text(H1), c("1 T1", "T2"))
+  H2 <- xml2::xml_find_all(TOC, ".//li/a")
+  expect_equal(xml2::xml_text(H2), c("1.1 CHAP1", "1.2 CHAP2"))
+})
+
+test_that("gitbook_toc correctly process pandoc html with anchor section", {
+  skip_on_cran()
+  skip_if_not_pandoc()
+  skip_if_not_installed("xml2")
+  rmd <- local_rmd_file(c("---", "title: test", "---", "",
+                          "# T1", "", "## CHAP1", "",
+                          "# T2 {-}", "", "## CHAP2"))
+  res <- local_render_book(rmd, output_format = gitbook(anchor_sections = TRUE))
+  content <- xml2::read_html(res)
+  TOC <- xml2::xml_find_all(content, "//div[@class='book-summary']/nav/ul/li")
+  expect_equal(xml2::xml_attr(TOC, "class"), c("chapter", "chapter"))
+  expect_equal(xml2::xml_attr(TOC, "data-level"), c("1", ""))
+  expect_equal(xml2::xml_attr(TOC, "data-path"), c("t1.html", "t2.html"))
+  H1 <- xml2::xml_find_all(TOC, "a")
+  expect_equal(xml2::xml_text(H1), c("1 T1", "T2"))
+  H2 <- xml2::xml_find_all(TOC, ".//li/a")
+  expect_equal(xml2::xml_text(H2), c("1.1 CHAP1", "1.2 CHAP2"))
+})

--- a/tests/testthat/test-html.R
+++ b/tests/testthat/test-html.R
@@ -1,17 +1,30 @@
-test_that("PART feature correctly works in HTML", {
+test_that("PART feature correctly works in HTML without anchor sections", {
   skip_on_cran()
   skip_if_not_pandoc()
   skip_if_not_installed("xml2")
   rmd <- local_rmd_file(c("---", "title: test", "---", "",
                           "# (PART) T1 {-}", "", "# CHAP1", "",
                           "# (PART\\*) T2 {-}", "", "# CHAP2"))
-  res <- local_render_book(rmd, output_format = gitbook())
+  res <- local_render_book(rmd, output_format = gitbook(anchor_sections = FALSE))
   content <- xml2::read_html(res)
   TOC <- xml2::xml_find_all(content, "//div[@class='book-summary']/nav/ul/li")
-  expect_equal(xml2::xml_attr(TOC, "class"), c("part", "NA", "part", "NA"))
+  expect_equal(xml2::xml_attr(TOC, "class"), c("part", "chapter", "part", "chapter"))
   expect_equal(xml2::xml_text(TOC), c("I T1", "1 CHAP1", "T2", "2 CHAP2"))
 })
 
+test_that("PART feature correctly works in HTML with anchor sections", {
+  skip_on_cran()
+  skip_if_not_pandoc()
+  skip_if_not_installed("xml2")
+  rmd <- local_rmd_file(c("---", "title: test", "---", "",
+                          "# (PART) T1 {-}", "", "# CHAP1", "",
+                          "# (PART\\*) T2 {-}", "", "# CHAP2"))
+  res <- local_render_book(rmd, output_format = gitbook(anchor_sections = TRUE))
+  content <- xml2::read_html(res)
+  TOC <- xml2::xml_find_all(content, "//div[@class='book-summary']/nav/ul/li")
+  expect_equal(xml2::xml_attr(TOC, "class"), c("part", "chapter", "part", "chapter"))
+  expect_equal(xml2::xml_text(TOC), c("I T1", "1 CHAP1", "T2", "2 CHAP2"))
+})
 
 test_that("build_404 creates correct 404 page", {
   skip_on_cran()

--- a/tests/testthat/test-html.R
+++ b/tests/testthat/test-html.R
@@ -1,3 +1,18 @@
+test_that("PART feature correctly works in HTML", {
+  skip_on_cran()
+  skip_if_not_pandoc()
+  skip_if_not_installed("xml2")
+  rmd <- local_rmd_file(c("---", "title: test", "---", "",
+                          "# (PART) T1 {-}", "", "# CHAP1", "",
+                          "# (PART\\*) T2 {-}", "", "# CHAP2"))
+  res <- local_render_book(rmd, output_format = gitbook())
+  content <- xml2::read_html(res)
+  TOC <- xml2::xml_find_all(content, "//div[@class='book-summary']/nav/ul/li")
+  expect_equal(xml2::xml_attr(TOC, "class"), c("part", "NA", "part", "NA"))
+  expect_equal(xml2::xml_text(TOC), c("I T1", "1 CHAP1", "T2", "2 CHAP2"))
+})
+
+
 test_that("build_404 creates correct 404 page", {
   skip_on_cran()
   skip_if_not_pandoc()


### PR DESCRIPTION
Fixes #1327 and close #1326 by dealing with empty spans introduced in gitbook. 

basically for #1327 we had our usual regex issue following Pandoc 2.187 changes. There was the PART issue, but also the unnumbered chapter not being dealt with correctly. 

We did not detect sooner because we did not have tests for this. So I took the time to add some more test for this - took me a while to master more XPATH but that will be useful for further tests. 