### PR TITLE
Add syntax highlighting for imports and built-ins tokens

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bookdown
 Type: Package
 Title: Authoring Books and Technical Documents with R Markdown
-Version: 0.26.2
+Version: 0.26.3
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("JJ", "Allaire", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN bookdown VERSION 0.27
 
+- Tweak `bs4_book()` default CSS for better support of python chunk highlighting (thanks, @briandk, #1333).
+
 - Fix an issue with guessing output format when no `output_format` is provided in `render_book()` for files in a `rmd_subdir` folder (thanks, @shivam7898, #1331).
 
 

--- a/inst/resources/bs4_book/bs4_book.css
+++ b/inst/resources/bs4_book/bs4_book.css
@@ -440,14 +440,14 @@ code span.er {color:#ff0000;}
 code span.bn {color:#a1024a}
 code span.al {color:#ff0000;}
 code span.va {color:#19177c}
-code span.bu {}
+code span.bu {color: #007faa;}
 code span.ex {}
 code span.pp {color:#bc7a00}
 code span.in {color:#545454;}
 code span.vs {color:#008000}
 code span.wa {color:#545454; font-style: italic}
 code span.do {color:#ba2121; font-style: italic}
-code span.im {}
+code span.im {color:#007faa; font-style: bold;}
 code span.ch {color:#008000}
 code span.dt {color:#aa5d00}
 code span.fl {color:#a1024a}
@@ -456,7 +456,7 @@ code span.cv {color:#545454; font-style: italic}
 code span.cn {color:#d91e18}
 code span.sc {color:#008000}
 code span.dv {color:#a1024a}
-code span.kw {color:#007faa;}
+code span.kw {color:#007faa; font-style: bold}
 
 /* Misc typography ---------------------------------------------- */
 

--- a/inst/resources/bs4_book/bs4_book.css
+++ b/inst/resources/bs4_book/bs4_book.css
@@ -447,7 +447,7 @@ code span.in {color:#545454;}
 code span.vs {color:#008000}
 code span.wa {color:#545454; font-style: italic}
 code span.do {color:#ba2121; font-style: italic}
-code span.im {color:#007faa; font-style: bold;}
+code span.im {color:#007faa; font-weight: bold;}
 code span.ch {color:#008000}
 code span.dt {color:#aa5d00}
 code span.fl {color:#a1024a}
@@ -456,7 +456,7 @@ code span.cv {color:#545454; font-style: italic}
 code span.cn {color:#d91e18}
 code span.sc {color:#008000}
 code span.dv {color:#a1024a}
-code span.kw {color:#007faa; font-style: bold}
+code span.kw {color:#007faa; font-weight: bold;}
 
 /* Misc typography ---------------------------------------------- */
 

--- a/inst/resources/bs4_book/bs4_book.css
+++ b/inst/resources/bs4_book/bs4_book.css
@@ -456,7 +456,7 @@ code span.cv {color:#545454; font-style: italic}
 code span.cn {color:#d91e18}
 code span.sc {color:#008000}
 code span.dv {color:#a1024a}
-code span.kw {color:#007faa; font-weight: bold;}
+code span.kw {color:#007faa}
 
 /* Misc typography ---------------------------------------------- */
 


### PR DESCRIPTION
## TL;DR

Currently bookdown's `bs4_book()` output format doesn't apply any particular syntax highlighting to code tokens of class "import" and "built-in". This PR tries to remedy that by applying sensible styles to tokens of those classes.

## Background

Much of the background on this issue can be found at https://github.com/jgm/skylighting/issues/147, but in short:

Right now the imports in a Python code chunk don't have any visually distinguishing features. A statement like this:

```python
from plotnine import geom_text
```

appears like this, with no coloring or font weight changes:

```
from plotnine import geom_text
```

The reason this code doesn't get styled by `bs4_book.css` is that the CSS file doesn't actually *have* any extra styling information for those types of tokens (import tokens, specifically, but the same is true for tokens of class built-in). Note the empty ruleset for `code span.im` here:

https://github.com/rstudio/bookdown/blob/6adacc3363315a9a49eb4fac370125a3d37ecaa5/inst/resources/bs4_book/bs4_book.css#L450

## What I've tried to do in this PR

I tried my best to preserve the current aesthetic of bs4_book's syntax highlighting palette while adding support for additional token types.

I took my inspiration from [Pygments defaults][pygments], trying to match colors and font weights without introducing any new colors to bs4_book's palette.

[pygments]: https://pygments.org/demo/?lexer=python&style=default&formatter=html&code=from+typing+import+Iterator%0A%0A%23+This+is+an+example%0Aclass+Math%3A%0A++++%40staticmethod%0A++++def+fib%28n%3A+int%29+-%3E+Iterator%5Bint%5D%3A%0A++++++++%22%22%22+Fibonacci+series+up+to+n+%22%22%22%0A++++++++a%2C+b+%3D+0%2C+1%0A++++++++while+a+%3C+n%3A%0A++++++++++++yield+a%0A++++++++++++a%2C+b+%3D+b%2C+a+%2B+b%0A%0Aresult+%3D+sum%28Math.fib%2842%29%29%0Aprint%28%22The+answer+is+%7B%7D%22.format%28result%29%29