### PR TITLE
fix #1358 remove unnecessary codes for clipboard

### DIFF
--- a/inst/resources/gitbook/js/plugin-clipboard.js
+++ b/inst/resources/gitbook/js/plugin-clipboard.js
@@ -8,13 +8,8 @@ gitbook.require(["gitbook", "jQuery"], function(gitbook, $) {
     if (!ClipboardJS.isSupported()) return;
 
     // the page.change event is thrown twice: before and after the page changes
-    if (clipboard) {
-      // clipboard is already defined
-      // we can deduct that we are before page changes
-      clipboard.destroy(); // destroy the previous events listeners
-      clipboard = undefined; // reset the clipboard object
-      return;
-    }
+    // avoid appending multiple event handlers 
+    if (clipboard) return;
 
     $(copyButton).prependTo("div.sourceCode");
 


### PR DESCRIPTION
This change works well in my local environment.

The `page.change` event 
- occurs twice: before and after the page changes.
- also occurs when clicking links to the same page at the left index.

Then,
- we do not need `clipboard.destroy();`, which destroys the event listener of `clipboard` and disables copying.
- we do not need `clipboard = undefined;`, which unintentionally assigns multiple event handlers to `clipboard` after the second `page.change` event.

So, just `if (clipboard) return;` enables the clipboard function to work and also avoids appending multiple event handlers to `clipboard`.

I would appreciate any feedback.