### PR TITLE
Fix Theorem / Proof environments with special markdown content

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bookdown
 Type: Package
 Title: Authoring Books and Technical Documents with R Markdown
-Version: 0.29.1
+Version: 0.29.2
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("JJ", "Allaire", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # CHANGES IN bookdown VERSION 0.30
 
+- Support specific markdown content like list or code chunk inside Theorem and Proof special environments (#1371).
 
 # CHANGES IN bookdown VERSION 0.29
 

--- a/inst/rmarkdown/lua/custom-environment.lua
+++ b/inst/rmarkdown/lua/custom-environment.lua
@@ -192,7 +192,6 @@ Div = function (div)
                 pandoc.Attr(id, {env_type.env})
             )
         end
-        print(span)
         if (div.content[1].t == "Para") then
           -- add to the first block of the div, and not as first block, only if a Para
           table.insert(div.content[1].content, 1, span)
@@ -200,7 +199,6 @@ Div = function (div)
           -- Otherwise adds as its own Para
           table.insert(div.content, 1, pandoc.Para(span))
         end
-        print(div)
     end
 
     return div

--- a/inst/rmarkdown/lua/custom-environment.lua
+++ b/inst/rmarkdown/lua/custom-environment.lua
@@ -188,8 +188,15 @@ Div = function (div)
                 pandoc.Attr(id, {env_type.env})
             )
         end
-        -- add to the first block of the div, and not as first block
-        table.insert(div.content[1].content, 1, span)
+        print(span)
+        if (div.content[1].t == "Para") then
+          -- add to the first block of the div, and not as first block, only if a Para
+          table.insert(div.content[1].content, 1, span)
+        else
+          -- Otherwise adds as its own Para
+          table.insert(div.content, 1, pandoc.Para(span))
+        end
+        print(div)
     end
 
     return div

--- a/inst/rmarkdown/lua/custom-environment.lua
+++ b/inst/rmarkdown/lua/custom-environment.lua
@@ -196,7 +196,7 @@ Div = function (div)
           -- add to the first block of the div, and not as first block, only if a Para
           table.insert(div.content[1].content, 1, span)
         else
-          -- Otherwise adds as its own Para
+          -- Otherwise add as its own Para
           table.insert(div.content, 1, pandoc.Para(span))
         end
     end

--- a/inst/rmarkdown/lua/custom-environment.lua
+++ b/inst/rmarkdown/lua/custom-environment.lua
@@ -147,6 +147,10 @@ Div = function (div)
             table.insert(div.content[1].content, 1, pandoc.RawInline('tex', beginEnv))
             table.insert(div.content[#div.content].content, pandoc.RawInline('tex', '\n' .. endEnv))
         else
+            if (div.content[1].t ~= "Para") then
+            -- required trick to get correct alignement
+              beginEnv = beginEnv.."\\leavevmode"
+            end
             table.insert(div.content, 1, pandoc.RawBlock('tex', beginEnv))
             table.insert(div.content, pandoc.RawBlock('tex', endEnv))
         end

--- a/tests/manual/theorem-proof-fenced.Rmd
+++ b/tests/manual/theorem-proof-fenced.Rmd
@@ -121,3 +121,21 @@ Containing Markdown syntax
 <strong>bold in html</strong>
 :::
 ```
+
+## Support some specific content inside the environment
+
+::: {#exr-1 .exercise}
+
+1)  Open RStudio.
+2)  Write `1 + 9` to console.
+:::
+
+::: {.exercise #exr-2}
+
+```r
+library(knitr)
+kable(mtcars)
+```
+Copy and paste the chunk above
+
+:::

--- a/tests/manual/theorem-proof-fenced.Rmd
+++ b/tests/manual/theorem-proof-fenced.Rmd
@@ -122,20 +122,32 @@ Containing Markdown syntax
 :::
 ```
 
-## Support some specific content inside the environment
-
 ::: {#exr-1 .exercise}
+1)  Open RStudio.
+2)  Write `1 + 9` to console.
+:::
+
+::: {.exercise}
+
+Do this:
 
 1)  Open RStudio.
 2)  Write `1 + 9` to console.
 :::
 
-::: {.exercise #exr-2}
-
+::: {.exercise}
 ```r
 library(knitr)
 kable(mtcars)
 ```
 Copy and paste the chunk above
+:::
 
+::: {.solution #sol-2}
+Copy and paste the chunk below
+
+```r
+library(knitr)
+kable(mtcars)
+```
 :::


### PR DESCRIPTION
This fixes #1371 and also make sure we handle other type of content like code chunk

````markdown

::: {#exr-1 .exercise}
1)  Open RStudio.
2)  Write `1 + 9` to console.
:::

::: {.exercise}
```r
library(knitr)
kable(mtcars)
```
Copy and paste the chunk above
:::
````

Adding `\leavevmode` was found in amsthm doc (http://www.ams.org/arc/tex/amscls/amsthdoc.pdf) - it is not the only way of doing it, but it seems to be required to correctly format the result in LaTeX. See explanation in the doc.

@yihui does it seems ok ? Do you think of other cases to test maybe ? I think the solution is general enough to support any usecase. 