### PR TITLE
Fix default math rendering in epub format

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Fix an issue with CSL using hanging indent style in `gitbook()` (thanks, @pablobernabeu, #1422).
 
+- Fix an issue with Pandoc 2.19 not rendering math by default in `epub3` format (#1417).
+
 # CHANGES IN bookdown VERSION 0.33
 
 - `extra_dependencies` in `gitbook()` is now correctly working (thanks, @ThierryO, #1408).

--- a/R/ebook.R
+++ b/R/ebook.R
@@ -46,7 +46,8 @@ epub_book = function(
     if (!is.null(cover_image)) c('--epub-cover-image', cover_image),
     if (!is.null(metadata)) c('--epub-metadata', metadata),
     if (!identical(template, 'default')) c('--template', template),
-    if (!missing(chapter_level)) c('--epub-chapter-level', chapter_level)
+    if (!missing(chapter_level)) c('--epub-chapter-level', chapter_level),
+    if (rmarkdown::pandoc_available("2.19") && epub_version == "epub3") c("--mathml")
   )
   if (is.null(stylesheet)) css = NULL else {
     css = rmarkdown::pandoc_path_arg(epub_css(stylesheet))

--- a/tests/testthat/test-ebook.R
+++ b/tests/testthat/test-ebook.R
@@ -1,0 +1,22 @@
+test_that("epub_book() correctly renders math without warning", {
+  skip_on_cran()
+  skip_if_not_pandoc()
+  skip_if_not_installed("jsonlite")
+  book <- local_book()
+  # add complex math
+  xfun::in_dir(
+    book,
+    xfun::write_utf8(c(
+      "# Methods",
+      "",
+      "Inserting Math",
+      "",
+      "$$",
+      "SE = \\sqrt(\\frac{p(1-p)}{n}) \\approx \\sqrt{\\frac{1/3 (1 - 1/3)} {300}} = 0.027",
+      "$$"
+    ), "03-Methods.Rmd")
+  )
+  file.create(tmp_file <- withr::local_tempfile(pattern = "pandoc", fileext = ".log"))
+  res <- .render_book_quiet(book, output_format = epub_book(pandoc_args = c(sprintf("--log=%s", tmp_file), "--quiet")))
+  expect_false("CouldNotConvertTeXMath" %in% jsonlite::fromJSON(tmp_file)$type)
+})


### PR DESCRIPTION
Fix breaking change of pandoc 2.19 as math has been made optional while previously it defaulted to `--mathml`

This closes #1417 by only putting back the default behavior prior to Pandoc 2.19 change. 

New feature to optionally opt-out or choose another method will be done in another PR probably. 