### PR TITLE
For pandoc 3.0+, use `--split-level`  when  `chapter_level` is passed in `epub_book`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 - Fix an issue with CSL using hanging indent style in `gitbook()` (thanks, @pablobernabeu, #1422).
 
-- Adapt `epub_book()` internal command line argument passed to Pandoc for changes from version 3.0 and above.
+- Adapt an `epub_book()` internal command-line argument passed to Pandoc for changes from version 3.0 and above (#1425).
 
 - Fix an issue with Pandoc 2.19 not rendering math by default in `epub3` format (#1417).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Fix an issue with CSL using hanging indent style in `gitbook()` (thanks, @pablobernabeu, #1422).
 
+- Adapt `epub_book()` internal command line argument passed to Pandoc for changes from version 3.0 and above.
+
 # CHANGES IN bookdown VERSION 0.33
 
 - `extra_dependencies` in `gitbook()` is now correctly working (thanks, @ThierryO, #1408).

--- a/R/ebook.R
+++ b/R/ebook.R
@@ -255,4 +255,3 @@ calibre = function(input, output, options = '') {
   if (!file.exists(output)) stop('Failed to convert ', input, ' to ', output)
   invisible(output)
 }
-

--- a/R/ebook.R
+++ b/R/ebook.R
@@ -46,7 +46,8 @@ epub_book = function(
     if (!is.null(cover_image)) c('--epub-cover-image', cover_image),
     if (!is.null(metadata)) c('--epub-metadata', metadata),
     if (!identical(template, 'default')) c('--template', template),
-    if (!missing(chapter_level)) c('--epub-chapter-level', chapter_level)
+    if (!missing(chapter_level))
+      c(if (rmarkdown::pandoc_available("3.0")) '--split-level' else '--epub-chapter-level', chapter_level)
   )
   if (is.null(stylesheet)) css = NULL else {
     css = rmarkdown::pandoc_path_arg(epub_css(stylesheet))
@@ -253,3 +254,4 @@ calibre = function(input, output, options = '') {
   if (!file.exists(output)) stop('Failed to convert ', input, ' to ', output)
   invisible(output)
 }
+


### PR DESCRIPTION
For you next release you are preparing @yihui

Closes #1416 

`--epub-chapter-level` is deprecated in favor of `--split-level` and throws a warning. We now use correct argument when pandoc 3 is used. 