### PR TITLE
Add config option to change MathJax renderer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # CHANGES IN bookdown VERSION 0.41
 
+- New `mathjax-config` config option to bs4_book and gitbook to control MathJax config string (thanks, @bwu62, #1472). Currently tested and supported settings:
+  - If empty, defaults to original `TeX-MML-AM_CHTML` which renders all equations in common HTML.
+  - If set to `TeX-AMS-MML_HTMLorMML` renders equations in HTML + CSS (which may look nicer for some equations).
+  - If set to `TeX-MML-AM_SVG` renders equations in SVG.
 
 # CHANGES IN bookdown VERSION 0.40
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # CHANGES IN bookdown VERSION 0.41
 
-- New `mathjax-config` config option to bs4_book and gitbook to control MathJax config string (thanks, @bwu62, #1472). Currently tested and supported settings:
+- New `mathjax-config` option for `bs4_book` and `gitbook` to control MathJax config string (thanks, @bwu62, #1472). The option can be set either in the YAML metadata or as a variable in `pandoc_args`. Currently tested and supported settings:
   - If empty, defaults to original `TeX-MML-AM_CHTML` which renders all equations in common HTML.
   - If set to `TeX-AMS-MML_HTMLorMML` renders equations in HTML + CSS (which may look nicer for some equations).
   - If set to `TeX-MML-AM_SVG` renders equations in SVG.

--- a/inst/templates/bs4_book.html
+++ b/inst/templates/bs4_book.html
@@ -158,7 +158,7 @@ $if(math)$
     var script = document.createElement("script");
     script.type = "text/javascript";
     var src = "$if(mathjax)$$mathjax$$endif$";
-    if (src === "" || src === "true") src = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/latest.js?config=TeX-MML-AM_CHTML";
+    if (src === "" || src === "true") src = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/latest.js?config=TeX-AMS-MML_HTMLorMML";
     if (location.protocol !== "file:")
       if (/^https?:/.test(src))
         src = src.replace(/^https?:/, '');

--- a/inst/templates/bs4_book.html
+++ b/inst/templates/bs4_book.html
@@ -158,7 +158,7 @@ $if(math)$
     var script = document.createElement("script");
     script.type = "text/javascript";
     var src = "$if(mathjax)$$mathjax$$endif$";
-    if (src === "" || src === "true") src = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/latest.js?config=$if(mathjax-renderer)$$mathjax-renderer$$else$TeX-MML-AM_CHTML$endif$";
+    if (src === "" || src === "true") src = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/latest.js?config=$if(mathjax-config)$$mathjax-config$$else$TeX-MML-AM_CHTML$endif$";
     if (location.protocol !== "file:")
       if (/^https?:/.test(src))
         src = src.replace(/^https?:/, '');

--- a/inst/templates/bs4_book.html
+++ b/inst/templates/bs4_book.html
@@ -158,7 +158,7 @@ $if(math)$
     var script = document.createElement("script");
     script.type = "text/javascript";
     var src = "$if(mathjax)$$mathjax$$endif$";
-    if (src === "" || src === "true") src = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/latest.js?config=TeX-AMS-MML_HTMLorMML";
+    if (src === "" || src === "true") src = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/latest.js?config=$if(mathjax-renderer)$$mathjax-renderer$$else$TeX-MML-AM_CHTML$endif$";
     if (location.protocol !== "file:")
       if (/^https?:/.test(src))
         src = src.replace(/^https?:/, '');

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -205,7 +205,7 @@ $if(math)$
     var script = document.createElement("script");
     script.type = "text/javascript";
     var src = "$if(mathjax)$$mathjax$$endif$";
-    if (src === "" || src === "true") src = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/latest.js?config=TeX-MML-AM_CHTML";
+    if (src === "" || src === "true") src = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/latest.js?config=$if(mathjax-renderer)$$mathjax-renderer$$else$TeX-MML-AM_CHTML$endif$";
     if (location.protocol !== "file:")
       if (/^https?:/.test(src))
         src = src.replace(/^https?:/, '');

--- a/inst/templates/gitbook.html
+++ b/inst/templates/gitbook.html
@@ -205,7 +205,7 @@ $if(math)$
     var script = document.createElement("script");
     script.type = "text/javascript";
     var src = "$if(mathjax)$$mathjax$$endif$";
-    if (src === "" || src === "true") src = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/latest.js?config=$if(mathjax-renderer)$$mathjax-renderer$$else$TeX-MML-AM_CHTML$endif$";
+    if (src === "" || src === "true") src = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/latest.js?config=$if(mathjax-config)$$mathjax-config$$else$TeX-MML-AM_CHTML$endif$";
     if (location.protocol !== "file:")
       if (/^https?:/.test(src))
         src = src.replace(/^https?:/, '');


### PR DESCRIPTION
Not 100% sure, but based on a small amount of testing, I think this may render more neatly without sacrificing on portability or speed.

I noticed this when typesetting the formula for the sample standard deviation

`$$s=\sqrt{\frac1{n-1}\sum_{i=1}^n(x_i-\bar{x})^2}$$`

The default MathJax renderer of "Common HTML" "fakes" the square root top bar by using a border, which causes annoying misalignment with the radical symbol beside it. It also overall looks a bit more raggedy and not as pretty.

This small config change switches the default renderer to HTML+CSS (thanks @dennissxz for [the tip](https://github.com/jupyter-book/jupyter-book/issues/1174#issuecomment-759857170)).

Seems to be a marginal improvement.