### PR TITLE
Change calls to `knitr:::%n%` to `%||%` as `%||%`  is a base function

### DIFF
--- a/R/bs4_book.R
+++ b/R/bs4_book.R
@@ -427,7 +427,7 @@ tweak_navbar <- function(html, toc, active = "", rmd_index = NULL, repo = NULL) 
   }
 
   if (!is.null(repo$base)) {
-    icon <- repo$icon %n%
+    icon <- repo$icon %||%
       ifelse(grepl("github\\.com", repo$base), "fab fa-github", "fab fa-gitlab")
     template_link_icon(html, ".//a[@id='book-repo']", icon)
     template_link_icon(html, ".//a[@id='book-source']", icon)

--- a/R/html.R
+++ b/R/html.R
@@ -881,7 +881,7 @@ add_chapter_prefix = function(content) {
 add_chapter_prefix_one = function(content, type = c('chapter', 'appendix')) {
   config = load_config()
   field = paste0(type, '_name')
-  chapter_name = config[[field]] %n% ui_language(field)
+  chapter_name = config[[field]] %||% ui_language(field)
   if (is.null(chapter_name) || identical(chapter_name, '')) return(content)
   chapter_fun = if (is.character(chapter_name)) {
     function(i) switch(

--- a/R/skeleton.R
+++ b/R/skeleton.R
@@ -113,7 +113,7 @@ skeleton_get_dir = function(...) {
 
 skeleton_get_files = function(subdir = NULL, relative = TRUE) {
   resources = skeleton_get_dir()
-  subdir = file.path(resources, subdir %n% "")
+  subdir = file.path(resources, subdir %||% "")
   if (!dir.exists(subdir)) return(NULL)
   files = list.files(subdir, recursive = TRUE, include.dirs = FALSE, full.names = TRUE)
   if (relative) xfun::relative_path(files, resources) else files

--- a/R/utils.R
+++ b/R/utils.R
@@ -489,6 +489,7 @@ verify_rstudio_version = function() {
 
 str_trim = function(x) gsub('^\\s+|\\s+$', '', x)
 
+if (getRversion() < '4.4.0') `%||%` = function(x, y) if (is.null(x)) y else x
 output_md = function() getOption('bookdown.output.markdown', FALSE)
 
 # a theorem engine for knitr (can also be used for lemmas, definitions, etc)

--- a/R/utils.R
+++ b/R/utils.R
@@ -70,7 +70,7 @@ get_base_format = function(format, options = list()) {
 }
 
 load_config = function(config_file = '_bookdown.yml') {
-  config_file = opts$get('config_file') %n% config_file
+  config_file = opts$get('config_file') %||% config_file
   if (length(opts$get('config')) == 0 && file.exists(config_file)) {
     # store the book config
     opts$set(config = rmarkdown:::yaml_load_file(config_file))
@@ -488,8 +488,6 @@ verify_rstudio_version = function() {
 }
 
 str_trim = function(x) gsub('^\\s+|\\s+$', '', x)
-
-`%n%` = knitr:::`%n%`
 
 output_md = function() getOption('bookdown.output.markdown', FALSE)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -490,6 +490,7 @@ verify_rstudio_version = function() {
 str_trim = function(x) gsub('^\\s+|\\s+$', '', x)
 
 if (getRversion() < '4.4.0') `%||%` = function(x, y) if (is.null(x)) y else x
+
 output_md = function() getOption('bookdown.output.markdown', FALSE)
 
 # a theorem engine for knitr (can also be used for lemmas, definitions, etc)


### PR DESCRIPTION
The functions `knitr:::%n%` and `%||%` are identical, but `%||%` is in `base` and `%n%` is an internal function of the `knitr` package.

The R documentation states that using triple colon operator inside packages is typically a design mistake (https://stat.ethz.ch/R-manual/R-devel/library/base/html/ns-dblcolon.html) and in this case it can and should be avoided.