### PR TITLE
Fix issue #956

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # CHANGES IN bookdown VERSION 0.42
 
 - New option in `gitbook`'s font settings menu to control line spacing (thanks, @hayden-MB, #1479).
-- New configuration setting `include_md` to control whether search includes `.md` source files in addition to `.Rmd`.
+
+- New configuration setting `include_md` to control whether the input search includes `.md` source files in addition to `.Rmd` (thanks, @katrinabrock #1483, @kylelundstedt #956).
 
 # CHANGES IN bookdown VERSION 0.41
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # CHANGES IN bookdown VERSION 0.42
 
 - New option in `gitbook`'s font settings menu to control line spacing (thanks, @hayden-MB, #1479).
+- New configuration setting `include_md` to control whether search includes `.md` source files in addition to `.Rmd`.
 
 # CHANGES IN bookdown VERSION 0.41
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -86,12 +86,13 @@ book_filename = function(config = load_config(), fallback = TRUE) {
 
 source_files = function(format = NULL, config = load_config(), all = FALSE) {
   subdir = config[['rmd_subdir']]; subdir_yes = isTRUE(subdir) || is.character(subdir)
+  ext_regex <- if(isTRUE(config[['include_md']])) '[.]R?md$' else '[.]Rmd$'
   # a list of Rmd chapters
-  files = list.files('.', '[.]Rmd$', ignore.case = TRUE)
+  files = list.files('.', ext_regex, ignore.case = TRUE)
   # content in subdir if asked
   subdir_files = unlist(mapply(
     list.files,
-    if (is.character(subdir)) subdir else '.', '[.]Rmd$', ignore.case = TRUE,
+    if (is.character(subdir)) subdir else '.', ext_regex, ignore.case = TRUE,
     recursive = subdir_yes, full.names = is.character(subdir), USE.NAMES = FALSE
   ))
   subdir_files = setdiff(subdir_files, files)

--- a/R/utils.R
+++ b/R/utils.R
@@ -86,7 +86,7 @@ book_filename = function(config = load_config(), fallback = TRUE) {
 
 source_files = function(format = NULL, config = load_config(), all = FALSE) {
   subdir = config[['rmd_subdir']]; subdir_yes = isTRUE(subdir) || is.character(subdir)
-  ext_regex <- if(isTRUE(config[['include_md']])) '[.]R?md$' else '[.]Rmd$'
+  ext_regex = if (isTRUE(config[['include_md']])) '[.]R?md$' else '[.]Rmd$'
   # a list of Rmd chapters
   files = list.files('.', ext_regex, ignore.case = TRUE)
   # content in subdir if asked

--- a/inst/examples/01-introduction.Rmd
+++ b/inst/examples/01-introduction.Rmd
@@ -124,7 +124,7 @@ rmd_files:
 ```
 
 Although we have been talking about R Markdown files, the chapter files do not actually have to be R Markdown. They can be plain Markdown files (`.md`), and do not have to contain R code chunks at all. You can certainly use **bookdown** to compose novels or poems!
-However, by default, `.md` files are not included in the automatic collection of files.
+However, by default, only `.Rmd` files (but not `.md` files) are included in the automatic collection of files.
 
 At the moment, the major output formats that you may use include `bookdown::pdf_book`, `bookdown::gitbook`, `bookdown::html_book`, and `bookdown::epub_book`. There is a `bookdown::render_book()`\index{bookdown::render\_book()} function similar to `rmarkdown::render()`, but it was designed to render _multiple_ Rmd documents into a book using the output format functions. You may either call this function from command line directly, or click the relevant buttons in the RStudio IDE. Here are some command-line examples:
 

--- a/inst/examples/01-introduction.Rmd
+++ b/inst/examples/01-introduction.Rmd
@@ -124,6 +124,7 @@ rmd_files:
 ```
 
 Although we have been talking about R Markdown files, the chapter files do not actually have to be R Markdown. They can be plain Markdown files (`.md`), and do not have to contain R code chunks at all. You can certainly use **bookdown** to compose novels or poems!
+However, by default, `.md` files are not included in the automatic collection of files.
 
 At the moment, the major output formats that you may use include `bookdown::pdf_book`, `bookdown::gitbook`, `bookdown::html_book`, and `bookdown::epub_book`. There is a `bookdown::render_book()`\index{bookdown::render\_book()} function similar to `rmarkdown::render()`, but it was designed to render _multiple_ Rmd documents into a book using the output format functions. You may either call this function from command line directly, or click the relevant buttons in the RStudio IDE. Here are some command-line examples:
 

--- a/inst/examples/04-customization.Rmd
+++ b/inst/examples/04-customization.Rmd
@@ -205,7 +205,7 @@ We have mentioned `rmd_files` in Section \@ref(usage), and there are more (optio
 -  `history`: similar to `edit`, a link to the edit/commit history of the current page.
 -  `view`: similar to `edit`, a link to source code of the current page. 
 - `rmd_subdir`: whether to search for book source Rmd files in subdirectories (by default, only the root directory is searched). This may be either a boolean (e.g. `true` will search for book source Rmd files in the project directory and all subdirectories) or list of paths if you want to search for book source Rmd files in a subset of subdirectories.
-- `include_md` include md files in search for book source (by default only Rmd files are included).
+- `include_md`: include `.md` files in search for book source (by default only `.Rmd` files are included).
 - `output_dir`: the output directory of the book (`_book` by default); this setting is read and used by `render_book()`.
 - `clean`: a vector of files and directories to be cleaned by the `clean_book()` function.
 

--- a/inst/examples/04-customization.Rmd
+++ b/inst/examples/04-customization.Rmd
@@ -205,6 +205,7 @@ We have mentioned `rmd_files` in Section \@ref(usage), and there are more (optio
 -  `history`: similar to `edit`, a link to the edit/commit history of the current page.
 -  `view`: similar to `edit`, a link to source code of the current page. 
 - `rmd_subdir`: whether to search for book source Rmd files in subdirectories (by default, only the root directory is searched). This may be either a boolean (e.g. `true` will search for book source Rmd files in the project directory and all subdirectories) or list of paths if you want to search for book source Rmd files in a subset of subdirectories.
+- `include_md` include md files in search for book source (by default only Rmd files are included).
 - `output_dir`: the output directory of the book (`_book` by default); this setting is read and used by `render_book()`.
 - `clean`: a vector of files and directories to be cleaned by the `clean_book()` function.
 

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -63,7 +63,7 @@ assert('source_files() handles several configurations correctly', {
   files = c(
     'index.Rmd', '_ignored.Rmd', '01-first.Rmd',
     'subdir/other.Rmd', 'subdir/_ignore.Rmd', 'subdir2/last.Rmd',
-    'abc/def.Rmd', 'abc/ghi.Rmd', 'subdir/jkl.md'
+    'abc/def.Rmd', 'abc/ghi.Rmd', 'abc/jkl.md'
   )
   lapply(unique(dirname(files)), dir.create, FALSE, recursive = TRUE)
   file.create(files)

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -53,8 +53,8 @@ assert('prepend_chapter_title() adds the chapter title to the page title', {
 })
 
 assert('source_files() handles several configurations correctly', {
-  get_files = function(files = NULL, dirs = NULL, ...) {
-    source_files(config = list(rmd_files = files, rmd_subdir = dirs), ...)
+  get_files = function(files = NULL, dirs = NULL, md = NULL, ...) {
+    source_files(config = list(rmd_files = files, rmd_subdir = dirs, include_md = md), ...)
   }
 
   # create dummy project
@@ -63,7 +63,7 @@ assert('source_files() handles several configurations correctly', {
   files = c(
     'index.Rmd', '_ignored.Rmd', '01-first.Rmd',
     'subdir/other.Rmd', 'subdir/_ignore.Rmd', 'subdir2/last.Rmd',
-    'abc/def.Rmd', 'abc/ghi.Rmd'
+    'abc/def.Rmd', 'abc/ghi.Rmd', 'subdir/jkl.md'
   )
   lapply(unique(dirname(files)), dir.create, FALSE, recursive = TRUE)
   file.create(files)
@@ -79,7 +79,7 @@ assert('source_files() handles several configurations correctly', {
   (get_files(files[4:1]) %==% files[c(1, 4, 3)])
 
   # format allows to filter selected files
-  (get_files(list(html = 'index.Rmd'), NULL, 'html') %==% files[1])
+  (get_files(list(html = 'index.Rmd'), NULL, NULL, 'html') %==% files[1])
 
   # rmd_subdir allows subdir contents and root Rmds
   (get_files(, TRUE) %==% files[c(1, 3, 7:8, 4, 6)])
@@ -92,6 +92,10 @@ assert('source_files() handles several configurations correctly', {
   (get_files(files[3], TRUE) %==% files[c(3, 7:8, 4, 6)])
   (get_files(files[3], dirname(files[c(4, 6)])) %==% files[c(3, 4, 6)])
   (get_files(files[3], dirname(files[c(4, 6, 7)])) %==% files[c(3, 4, 6, 7:8)])
+
+  # include_md toggles inclusion of md files
+  (get_files(files[3], dirname(files[c(4, 6, 7)]), FALSE) %==% files[c(3, 4, 6, 7:8)])
+  (get_files(files[3], dirname(files[c(4, 6, 7)]), TRUE) %==% files[c(3, 4, 6, 7:9)])
 
   # clean tests
   unlink(project, recursive = TRUE); rm(project)


### PR DESCRIPTION
Adds `include_md` option which toggles whether `.md` files are included in bookdown's search for source files. Default is not to include them soas not to introduce a breaking change.