### PR TITLE
Full book is now deployed to gh-pages to be deployed to Connect cloud

### DIFF
--- a/.github/workflows/Book.yaml
+++ b/.github/workflows/Book.yaml
@@ -90,7 +90,7 @@ jobs:
         run: make -C inst/examples gitbook bs4_book
 
       - name: Build and Deploy all book
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         env:
           CONNECT_API_KEY: ${{ secrets.RSC_BOOKDOWN_ORG_TOKEN }}
           CONTENT_ID: 3

--- a/.github/workflows/Book.yaml
+++ b/.github/workflows/Book.yaml
@@ -85,15 +85,7 @@ jobs:
           key: bookdown-${{ hashFiles('inst/examples/*Rmd') }}
           restore-keys: bookdown-
 
-      - name: Test build of HTML books
-        if: github.event_name == 'pull_request'
-        run: make -C inst/examples gitbook bs4_book
-
-      - name: Build and Deploy all book
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        env:
-          CONNECT_API_KEY: ${{ secrets.RSC_BOOKDOWN_ORG_TOKEN }}
-          CONTENT_ID: 3
+      - name: Build all book formats
         run: make -C inst/examples all
 
       - name: Deploy Gitbook to gh-pages

--- a/.github/workflows/Book.yaml
+++ b/.github/workflows/Book.yaml
@@ -21,10 +21,11 @@ on:
       - '.github/workflows/Book.yaml'
   workflow_dispatch:
     inputs:
-      ghpages:
-        description: 'Build gitbook with pandoc devel and deploy gitbook to gh-page for checking differences'
+      publish:
+        description: 'publish the book to github pages for connect cloud deployment'
         required: false
-        default: true
+        default: false
+        type: boolean
 
 name: Build and deploy book
 
@@ -45,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install R
         uses: r-lib/actions/setup-r@v2
@@ -53,9 +54,7 @@ jobs:
       - name: Install Pandoc
         uses: r-lib/actions/setup-pandoc@v2
         with:
-          # install nightly when checking on gh-pages
-          pandoc-version: ${{ github.event.inputs.ghpages && 'nightly' || '3.8' }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          pandoc-version: latest
 
       - name: Install TinyTeX
         uses: r-lib/actions/setup-tinytex@v2
@@ -97,18 +96,14 @@ jobs:
           CONTENT_ID: 3
         run: make -C inst/examples all
 
-      - name: Build Gitbook only
-        env:
-          DEPLOY_GH_PAGES: ${{ github.event.inputs.ghpages }}
-        if: github.event_name == 'workflow_dispatch'
-        run: make -C inst/examples gitbook
-
       - name: Deploy Gitbook to gh-pages
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.ghpages
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' && 
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: inst/examples/_book
+          clean: true
+          dry-run: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.publish) || false }}
 
       - name: Upload book folder for debug
         if: failure()

--- a/.github/workflows/Book.yaml
+++ b/.github/workflows/Book.yaml
@@ -97,13 +97,13 @@ jobs:
         run: make -C inst/examples all
 
       - name: Deploy Gitbook to gh-pages
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' && 
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: inst/examples/_book
           clean: true
-          dry-run: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.publish) || false }}
+          dry-run: ${{ (github.event_name == 'workflow_dispatch' && (github.event.inputs.publish == 'false' || github.event.inputs.publish == false)) || false }}
 
       - name: Upload book folder for debug
         if: failure()

--- a/.github/workflows/Book.yaml
+++ b/.github/workflows/Book.yaml
@@ -103,6 +103,7 @@ jobs:
           branch: gh-pages
           folder: inst/examples/_book
           clean: true
+          single-commit: true
           dry-run: ${{ (github.event_name == 'workflow_dispatch' && (github.event.inputs.publish == 'false' || github.event.inputs.publish == false)) || false }}
 
       - name: Upload book folder for debug

--- a/inst/examples/_render.R
+++ b/inst/examples/_render.R
@@ -1,8 +1,5 @@
 quiet = "--quiet" %in% commandArgs(FALSE)
 formats = commandArgs(TRUE)
-# travis is still use for github page deployment
-# TODO: Remove github page deployment
-ghpages = identical(Sys.getenv("DEPLOY_GH_PAGES", NA), "true")
 
 
 src = (function() {
@@ -34,44 +31,11 @@ for (f in list.files('_book', '[.]html$', full.names = TRUE)) {
   x = readLines(f)
 
   if (length(i <- grep('^\\s*<body>\\s*$', x)) == 0) next
-  # patch HTML files when published to gh-pages to redirect to bookdown.org
-  if (ghpages) x[i[1]] = '<body onload="window.location = \'https://bookdown.org/yihui\'+location.pathname">'
   i = grep('<i class="fa fa-circle-o-notch fa-spin"></i><a href="./">.+</a>', x)[1]
   # shorter title on the toolbar
   if (!is.na(i)) x[i] = gsub('bookdown: ', '', x[i], fixed = TRUE)
-  # Remove some lines when published to gh-pages
-  if (ghpages) {
-    i = c(
-      grep('&lt;bytecode: 0x[0-9a-f]+&gt;$', x),
-      grep('^\\s*<meta name="generator" content="bookdown [.0-9]+ and GitBook [.0-9]+" />$', x),
-      grep('^<meta name="date" content="[-0-9]+" />$', x)
-    )
-    if (length(i)) x = x[-i]
-  }
 
   writeLines(x, f)
-}
-
-# When several format are rendered, usually when make all is called,
-# then we publish everything to bookdown.org
-if (length(formats) > 1 && !ghpages) {
-  message(">> Publishing Books")
-  if (!is.na(Sys.getenv("CI", NA))) {
-    # On CI connect to server, using API KEY and deploy using appId
-    rsconnect::addServer('https://bookdown.org', 'bookdown.org')
-    rsconnect::connectApiUser(
-      account = 'GHA', server = 'bookdown.org',
-      apiKey = Sys.getenv('CONNECT_API_KEY')
-    )
-    rsconnect::deploySite(
-      appId = Sys.getenv('CONTENT_ID'),
-      server = 'bookdown.org',
-      render = 'none', logLevel = 'verbose',
-      forceUpdate = TRUE)
-  } else {
-    # for local deployment when rsconnect/ is available
-    bookdown::publish_book('bookdown', server = 'bookdown.org', render = 'none')
-  }
 }
 
 setwd(owd)

--- a/inst/examples/_render.R
+++ b/inst/examples/_render.R
@@ -1,7 +1,6 @@
 quiet = "--quiet" %in% commandArgs(FALSE)
 formats = commandArgs(TRUE)
 
-
 src = (function() {
   attr(body(sys.function()), 'srcfile')
 })()$filename


### PR DESCRIPTION


This changes the workflow, and simplifies the `_render.R`

This also means we don't have a build of the book using pandoc devel anymore to check for problems. 

We would need another branch if we want that. 

Companion to 
- #1512 
