### PR TITLE
Make connect.posit.cloud the default if no accounts configured

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -89,7 +89,7 @@ Suggests:
 URL: https://github.com/rstudio/bookdown, https://pkgs.rstudio.com/bookdown/
 BugReports: https://github.com/rstudio/bookdown/issues
 SystemRequirements: Pandoc (>= 1.17.2)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Encoding: UTF-8
 Config/Needs/book: remotes, webshot, svglite
 Config/Needs/website: pkgdown, tidyverse/tidytemplate, rstudio/quillt

--- a/R/publish.R
+++ b/R/publish.R
@@ -8,7 +8,7 @@
 #' @param account Account name to publish to. Will default to any previously
 #'   published to account or any single account already associated with
 #'   \code{server}.
-#' @param server Server to publish to (by default connect.posit.cloud but
+#' @param server Server to publish to (by default connect.posit.cloud, but
 #'   any Posit Connect server can be published to).
 #'
 #' @export

--- a/R/publish.R
+++ b/R/publish.R
@@ -32,5 +32,8 @@ publish_book = function(
   }
 
   # deploy the book
-  rsconnect::deploySite(siteDir = getwd(), siteName = name, account = account, server = server, ...)
+  rsconnect::deploySite(
+    siteDir = getwd(), siteName = name, account = account, server = server,
+    render = render, logLevel = 'normal'
+  )
 }

--- a/R/publish.R
+++ b/R/publish.R
@@ -12,33 +12,27 @@
 #' @param account Account name to publish to. Will default to any previously
 #'   published to account or any single account already associated with
 #'   \code{server}.
-#' @param server Server to publish to (by default beta.rstudioconnect.com but
-#'   any RStudio Connect server can be published to).
+#' @param server Server to publish to (by default connect.posit.cloud but
+#'   any Posit Connect server can be published to).
 #'
 #' @export
 publish_book = function(
   name = NULL, account = NULL, server = NULL, render = c("none", "local", "server")
 ) {
 
-  # if there are no RS Connect accounts setup on this machine
-  # then offer to add one for bookdown.org
+  # if there are no Connect accounts setup on this machine
+  # then offer to add one for connect.posit.cloud
   accounts <- rsconnect::accounts()
   accounts <- subset(accounts, server != "shinyapps.io")
   if (is.null(accounts) || nrow(accounts) == 0) {
-
-    # add the server if we need to
-    servers = rsconnect::servers()
-    if (nrow(subset(servers, name == 'bookdown.org')) == 0)
-      rsconnect::addServer("https://bookdown.org/__api__", 'bookdown.org')
-
     # see if they want to configure an account (bail if they don't)
-    message('You do not currently have a bookdown.org publishing account ',
+    message('You do not currently have a publishing account ',
             'configured on this system.')
     result = readline('Would you like to configure one now? [Y/n]: ')
     if (tolower(result) == 'n') return(invisible())
 
     # configure the account
-    rsconnect::connectUser(server = 'bookdown.org')
+    rsconnect::connectCloudUser()
   }
 
   # deploy the book

--- a/R/publish.R
+++ b/R/publish.R
@@ -2,6 +2,9 @@
 #'
 #' Publish a book to a Connect Server. By default, you should render the book
 #' locally before publishing.
+#' 
+#' @inheritParams rsconnect::deploySite
+#' 
 #' @param name Name of the book (this will be used in the URL path of the
 #'   published book). Defaults to the \code{book_filename} in
 #'   \code{_bookdown.yml} if not specified.

--- a/man/publish_book.Rd
+++ b/man/publish_book.Rd
@@ -20,8 +20,8 @@ published book). Defaults to the \code{book_filename} in
 published to account or any single account already associated with
 \code{server}.}
 
-\item{server}{Server to publish to (by default beta.rstudioconnect.com but
-any RStudio Connect server can be published to).}
+\item{server}{Server to publish to (by default connect.posit.cloud but
+any Posit Connect server can be published to).}
 
 \item{render}{Rendering behavior for site:
 \itemize{

--- a/man/publish_book.Rd
+++ b/man/publish_book.Rd
@@ -22,6 +22,17 @@ published to account or any single account already associated with
 
 \item{server}{Server to publish to (by default connect.posit.cloud, but
 any Posit Connect server can be published to).}
+
+\item{render}{Rendering behavior for site:
+\itemize{
+\item \code{"none"} uploads a static version of the current contents of
+the site directory.
+\item \code{"local"} renders the site locally then uploads it.
+\item \code{"server"} uploads the source of the site to render on the server.
+}
+
+Note that for \code{"none"} and \code{"local"} source files (e.g. \code{.R}, \code{.Rmd} and
+\code{.md}) will not be uploaded to the server.}
 }
 \description{
 Publish a book to a Connect Server. By default, you should render the book

--- a/man/publish_book.Rd
+++ b/man/publish_book.Rd
@@ -4,7 +4,12 @@
 \alias{publish_book}
 \title{Publish a book to a Posit Connect server}
 \usage{
-publish_book(name = NULL, account = NULL, server = "connect.posit.cloud", ...)
+publish_book(
+  name = NULL,
+  account = NULL,
+  server = NULL,
+  render = c("none", "local", "server")
+)
 }
 \arguments{
 \item{name}{Name of the book (this will be used in the URL path of the
@@ -15,16 +20,10 @@ published book). Defaults to the \code{book_filename} in
 published to account or any single account already associated with
 \code{server}.}
 
-\item{server}{Server to publish to (by default connect.posit.cloud, but any
-Posit Connect server can be published to).}
-
-\item{...}{Other arguments to be passed to [rsconnect::deploySite()].}
+\item{server}{Server to publish to (by default connect.posit.cloud, but
+any Posit Connect server can be published to).}
 }
 \description{
 Publish a book to a Connect Server. By default, you should render the book
 locally before publishing.
-}
-\note{
-Previously the default server was bookdown.org, which will be sunset.
-  You are no longer recommended to publish to bookdown.org.
 }

--- a/man/render_book.Rd
+++ b/man/render_book.Rd
@@ -70,12 +70,12 @@ new R session (\code{new_session = TRUE}).
 }
 \examples{
 # see https://bookdown.org/yihui/bookdown for the full documentation
-if (file.exists("index.Rmd")) bookdown::render_book("index.Rmd")
+if (file.exists('index.Rmd')) bookdown::render_book('index.Rmd')
 \dontrun{
 # will use the default format defined in index.Rmd or _output.yml
 bookdown::render_book("index.Rmd")
 # will use the options for format defined in YAML metadata
-bookdown::render_book("index.Rmd", "bookdown::pdf_book")
+bookdown::render_book("index.Rmd",  "bookdown::pdf_book")
 # If you pass an output format object, it must have all the options set
 bookdown::render_book("index.Rmd", bookdown::pdf_book(toc = FALSE))
 

--- a/man/resolve_refs_html.Rd
+++ b/man/resolve_refs_html.Rd
@@ -25,7 +25,12 @@ the R Markdown source document.
 }
 \examples{
 library(bookdown)
-resolve_refs_html(c("<caption>(#tab:foo) A nice table.</caption>",
-    "<p>See Table @ref(tab:foo).</p>"), global = TRUE)
+resolve_refs_html(
+  c(
+    '<caption>(#tab:foo) A nice table.</caption>',
+    '<p>See Table @ref(tab:foo).</p>'
+  ),
+  global = TRUE
+)
 }
 \keyword{internal}


### PR DESCRIPTION
Alternative to #1512 that preserves the existing behavior of `publish_book()` and only suggests connect.posit.cloud instead of bookdown.org if you don't have any accounts configured in rsconnect yet.