### PR TITLE
rsconnect 1.6.0 is required for connectCloudUser()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -76,7 +76,7 @@ Suggests:
     curl,
     rstudioapi,
     miniUI,
-    rsconnect (>= 0.4.3),
+    rsconnect (>= 1.6.0),
     servr (>= 0.13),
     shiny,
     tibble,

--- a/R/publish.R
+++ b/R/publish.R
@@ -10,6 +10,9 @@
 #'   You are no longer recommended to publish to bookdown.org.
 #' @export
 publish_book = function(name = NULL, ...) {
+  if (!xfun::pkg_available("rsconnect", "1.6.0")) {
+    stop("Please install/upgrade the 'rsconnect' package (>= 1.6.0) to use this function.")
+  }
   # delete local records of bookdown.org
   accounts = rsconnect::accounts()
   x1 = 'bookdown.org' %in% accounts$server


### PR DESCRIPTION
@yihui I think this is needed for better user experience

- 1.6.0 is required for the function we use
- rsconnect is only a suggests, so we need to check before using it right ? 

Related to #1515 depending if **rsconnect** 1.6.3 goes on CRAN before bookdown.