### PR TITLE
docs: fix typos in documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,7 +11,7 @@ You can contribute in many ways:
 
 ## To submit a contribution using a Pull Request:
 
-1.  [Fork](https://github.com/rstudio/bookdown/fork) the repository and make your changes in a new branch specific to the PR. It is ok to edit a file in this repository using the `Edit` button on Github if the change is simple enough.
+1.  [Fork](https://github.com/rstudio/bookdown/fork) the repository and make your changes in a new branch specific to the PR. It is ok to edit a file in this repository using the `Edit` button on GitHub if the change is simple enough.
 
 2. For significant changes (e.g not required for fixing typos), ensure that you have signed the [individual](https://www.rstudio.com/wp-content/uploads/2014/06/rstudioindividualcontributoragreement.pdf) or [corporate](https://www.rstudio.com/wp-content/uploads/2014/06/rstudiocorporatecontributoragreement.pdf) contributor agreement as appropriate. You can send the signed copy to <contribute@rstudio.com>.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -47,7 +47,7 @@
 
 # CHANGES IN bookdown VERSION 0.39
 
-- Fixed a bug that `bs4_book()` errors on generating document description. The error occured when the beggining of the document is a very long sentence without spaces (> 197 characters), which typically happens in CJK languages (thanks, @atusy, #1463).
+- Fixed a bug that `bs4_book()` errors on generating document description. The error occurred when the beginning of the document is a very long sentence without spaces (> 197 characters), which typically happens in CJK languages (thanks, @atusy, #1463).
 
 # CHANGES IN bookdown VERSION 0.38
 
@@ -597,7 +597,7 @@
 
 - The `gitbook` output format also supports `abstract` in YAML now (thanks, @maxheld83, #311).
 
-- For the `gitbook` output format, the `downloads` option in `config` supports `rmd` now (e.g. `download: ["pdf", "epub", "rmd"]`) if the edit link has been specified and is a link to Github (thanks, @coatless, #330).
+- For the `gitbook` output format, the `downloads` option in `config` supports `rmd` now (e.g. `download: ["pdf", "epub", "rmd"]`) if the edit link has been specified and is a link to GitHub (thanks, @coatless, #330).
 
 - You can set the global R option `bookdown.post.latex` via `options()` to be a function to post-process the LaTeX output of the `pdf_book` format; see `?bookdown::pdf_book` for details (thanks, @nicksolomon, #373).
 
@@ -627,7 +627,7 @@
 
 ## NEW FEATURES
 
-- Added a Github button in the group of sharing buttons on the toolbar. By default, this button is not displayed. You have to set `github: yes` under `sharing` in the `gitbook` configurations (https://pkg.yihui.org/bookdown/html.html) and specify your Github repo using the top-level option `github-repo` in the YAML metadata of `index.Rmd`, e.g. `github-repo: rstudio/bookdown`.
+- Added a GitHub button in the group of sharing buttons on the toolbar. By default, this button is not displayed. You have to set `github: yes` under `sharing` in the `gitbook` configurations (https://pkg.yihui.org/bookdown/html.html) and specify your GitHub repo using the top-level option `github-repo` in the YAML metadata of `index.Rmd`, e.g. `github-repo: rstudio/bookdown`.
 
 - The appendix heading will be preserved in `bookdown::html_document2` output, e.g. if you have `# (APPENDIX) Appendix {-}` in your document, you will see the heading `Appendix` in the output. Previously it was removed.
 


### PR DESCRIPTION
## Summary
Fixes spelling/typo issues in project documentation files.

**Details:** Fix documentation typos: occured->occurred (x1); beggining->beginning (x1); Github->GitHub (x4)

**Files:**
- `NEWS.md`
- `.github/CONTRIBUTING.md`

Documentation-only change; no functional code updates.
