### PR TITLE
Fix LaTeX book build: replace obsolete caption 'bf' option

### DIFF
--- a/inst/examples/latex/preamble.tex
+++ b/inst/examples/latex/preamble.tex
@@ -1,6 +1,6 @@
 \usepackage{booktabs}
 \usepackage{longtable}
-\usepackage[bf,singlelinecheck=off]{caption}
+\usepackage[labelfont=bf,singlelinecheck=off]{caption}
 
 \usepackage{Alegreya}
 \usepackage[scale=.7]{sourcecodepro}


### PR DESCRIPTION
## Problem

The `Book.yaml` workflow failed on the latest `main` push ([run 33177622060](https://github.com/rstudio/bookdown/actions/runs/33177622060)) with:

```
! Package caption Error: bf undefined.
Error: LaTeX failed to compile bookdown.tex.
```

## Cause

The `caption` LaTeX package removed its legacy shorthand options (`bf`, `it`, `sf`, ...) in a recent update. Our preamble passed `bf`, which mapped to the obsolete `\bf` font command → `bf undefined`.

## Fix

`inst/examples/latex/preamble.tex`: `[bf,singlelinecheck=off]` → `[labelfont=bf,singlelinecheck=off]`. `labelfont=bf` bolds the caption label ("Figure X:"), matching the old behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)